### PR TITLE
feat: add Antigravity in the list of Agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.5.0] - 2026-02-28
+
+- Add support for Antigravity
+
 ## [1.4.0] - 2026-02-28
 
 - Add support for MCPorter

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Add MCP servers to your favorite coding agents with a single command.
 
-Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VSCode** and [8 more](#supported-agents).
+Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VSCode** and [9 more](#supported-agents).
 
 ## Install an MCP Server
 
@@ -138,6 +138,7 @@ MCP servers can be installed to any of these agents:
 
 | Agent                  | `--agent`            | Project Path            | Global Path                                                                                                     |
 | ---------------------- | -------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Antigravity            | `antigravity`        | -                       | `~/.gemini/antigravity/mcp_config.json`                                                                         |
 | Cline VSCode Extension | `cline`              | -                       | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
 | Cline CLI              | `cline-cli`          | -                       | `~/.cline/data/settings/cline_mcp_settings.json`                                                                |
 | Claude Code            | `claude-code`        | `.mcp.json`             | `~/.claude.json`                                                                                                |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",
@@ -27,6 +27,7 @@
     "mcp",
     "model-context-protocol",
     "ai-agents",
+    "antigravity",
     "cline",
     "claude-code",
     "claude-desktop",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -42,6 +42,12 @@ function getPlatformPaths() {
 }
 
 const { appSupport, vscodePath, gooseConfigPath } = getPlatformPaths();
+const antigravityConfigPath = join(
+  home,
+  ".gemini",
+  "antigravity",
+  "mcp_config.json",
+);
 const clineCliConfigPath = join(
   process.env.CLINE_DIR || join(home, ".cline"),
   "data",
@@ -264,6 +270,21 @@ function resolveMcporterConfigPath(
 }
 
 export const agents: Record<AgentType, AgentConfig> = {
+  antigravity: {
+    name: "antigravity",
+    displayName: "Antigravity",
+    configPath: antigravityConfigPath,
+    projectDetectPaths: [], // Global only - no project support
+    configKey: "mcpServers",
+    format: "json",
+    supportedTransports: ["stdio"],
+    unsupportedTransportMessage:
+      "Antigravity only supports local (stdio) servers via its config file. Use mcp-remote to connect to remote servers.",
+    detectGlobalInstall: async () => {
+      return existsSync(join(home, ".gemini"));
+    },
+  },
+
   cline: {
     name: "cline",
     displayName: "Cline VSCode Extension",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export type AgentType =
+  | "antigravity"
   | "cline"
   | "cline-cli"
   | "claude-code"

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -60,9 +60,10 @@ function cleanup() {
 // Agent Configuration Tests
 // ============================================
 
-test("getAgentTypes returns all 13 agents", () => {
+test("getAgentTypes returns all 14 agents", () => {
   const types = getAgentTypes();
-  assert.strictEqual(types.length, 13);
+  assert.strictEqual(types.length, 14);
+  assert.ok(types.includes("antigravity"));
   assert.ok(types.includes("cline"));
   assert.ok(types.includes("cline-cli"));
   assert.ok(types.includes("claude-code"));
@@ -137,9 +138,10 @@ test("getProjectCapableAgents returns 9 agents", () => {
   assert.ok(projectAgents.includes("zed"));
 });
 
-test("getGlobalOnlyAgents returns 4 agents", () => {
+test("getGlobalOnlyAgents returns 5 agents", () => {
   const globalAgents = getGlobalOnlyAgents();
-  assert.strictEqual(globalAgents.length, 4);
+  assert.strictEqual(globalAgents.length, 5);
+  assert.ok(globalAgents.includes("antigravity"));
   assert.ok(globalAgents.includes("cline"));
   assert.ok(globalAgents.includes("cline-cli"));
   assert.ok(globalAgents.includes("claude-desktop"));
@@ -339,6 +341,33 @@ test("isTransportSupported - most agents support sse", () => {
       `${type} should support sse`,
     );
   }
+});
+
+test("isTransportSupported - antigravity only supports stdio", () => {
+  assert.strictEqual(
+    isTransportSupported("antigravity", "stdio"),
+    true,
+    "antigravity should support stdio",
+  );
+  assert.strictEqual(
+    isTransportSupported("antigravity", "http"),
+    false,
+    "antigravity should not support http",
+  );
+  assert.strictEqual(
+    isTransportSupported("antigravity", "sse"),
+    false,
+    "antigravity should not support sse",
+  );
+});
+
+test("antigravity has unsupportedTransportMessage", () => {
+  const msg = agents.antigravity.unsupportedTransportMessage;
+  assert.ok(msg, "antigravity should have an unsupportedTransportMessage");
+  assert.ok(
+    msg.includes("mcp-remote"),
+    "message should mention mcp-remote guidance",
+  );
 });
 
 test("isTransportSupported - claude-desktop only supports stdio", () => {

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -288,6 +288,82 @@ test("E2E CLI: stdio server to claude-desktop succeeds", () => {
   assert.strictEqual(server.command, "npx");
 });
 
+test("E2E CLI: remote server to antigravity errors with custom message", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    ["https://mcp.example.com/mcp", "-a", "antigravity", "-y"],
+    projectDir,
+    homeDir,
+  );
+
+  assert.notStrictEqual(result.status, 0, "CLI should exit with non-zero");
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(
+    output,
+    /don't support http transport/,
+    "should report unsupported transport",
+  );
+  assert.match(output, /mcp-remote/, "should include mcp-remote guidance");
+});
+
+test("E2E CLI: --all skips antigravity for remote server with custom message", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    ["https://mcp.example.com/mcp", "--all", "-y"],
+    projectDir,
+    homeDir,
+  );
+
+  assert.strictEqual(result.status, 0, "CLI should succeed");
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(
+    output,
+    /Skipping agents.*Antigravity/,
+    "should warn about skipping Antigravity",
+  );
+  assert.match(output, /mcp-remote/, "should include mcp-remote guidance");
+});
+
+test("E2E CLI: stdio server to antigravity succeeds", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "@modelcontextprotocol/server-filesystem",
+      "-a",
+      "antigravity",
+      "-y",
+      "--name",
+      "filesystem",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = join(homeDir, ".gemini", "antigravity", "mcp_config.json");
+  assert.strictEqual(existsSync(configPath), true);
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const servers = saved.mcpServers as Record<string, unknown>;
+  assert.ok(servers.filesystem, "filesystem server should be configured");
+
+  const server = servers.filesystem as Record<string, unknown>;
+  assert.strictEqual(server.command, "npx");
+});
+
 cleanup();
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
- [x] Support for Antigravity (global install only)
- [x] Adding `mcp-remote` bridge for `stdio` only agents.
- [x] remove unused banner
- [x] added some tests for this PR  


<img width="410" height="572" alt="Screenshot 2026-02-22 at 4 03 49 PM" src="https://github.com/user-attachments/assets/293ac57c-ae12-4ae1-8e33-f82779a6ce8a" />
