### PR TITLE
add github-copilot-cli agent support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.0] - 2026-02-14
+
+add `github-copilot-cli` (Copilot CLI) support with project installs written to `.vscode/mcp.json` (same as VS Code) and global installs written to `~/.copilot/mcp-config.json` (`mcpServers`)
+
 ## [1.0.1] - 2026-02-14
 
 fix OpenCode config detection and MCP command generation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Add MCP servers to your favorite coding agents with a single command.
 
-Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VSCode** and [4 more](#supported-agents).
+Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VSCode** and [5 more](#supported-agents).
 
 ## Install an MCP Server
 
@@ -135,17 +135,18 @@ Agents that do not support headers: Goose.
 
 MCP servers can be installed to any of these agents:
 
-| Agent          | `--agent`        | Project Path            | Global Path                                                       |
-| -------------- | ---------------- | ----------------------- | ----------------------------------------------------------------- |
-| Claude Code    | `claude-code`    | `.mcp.json`             | `~/.claude.json`                                                  |
-| Claude Desktop | `claude-desktop` | -                       | `~/Library/Application Support/Claude/claude_desktop_config.json` |
-| Codex          | `codex`          | `.codex/config.toml`    | `~/.codex/config.toml`                                            |
-| Cursor         | `cursor`         | `.cursor/mcp.json`      | `~/.cursor/mcp.json`                                              |
-| Gemini CLI     | `gemini-cli`     | `.gemini/settings.json` | `~/.gemini/settings.json`                                         |
-| Goose          | `goose`          | `.goose/config.yaml`    | `~/.config/goose/config.yaml`                                     |
-| OpenCode       | `opencode`       | `opencode.json`         | `~/.config/opencode/opencode.json`                                |
-| VS Code        | `vscode`         | `.vscode/mcp.json`      | `~/Library/Application Support/Code/User/mcp.json`                |
-| Zed            | `zed`            | `.zed/settings.json`    | `~/Library/Application Support/Zed/settings.json`                 |
+| Agent              | `--agent`            | Project Path            | Global Path                                                       |
+| ------------------ | -------------------- | ----------------------- | ----------------------------------------------------------------- |
+| Claude Code        | `claude-code`        | `.mcp.json`             | `~/.claude.json`                                                  |
+| Claude Desktop     | `claude-desktop`     | -                       | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Codex              | `codex`              | `.codex/config.toml`    | `~/.codex/config.toml`                                            |
+| Cursor             | `cursor`             | `.cursor/mcp.json`      | `~/.cursor/mcp.json`                                              |
+| Gemini CLI         | `gemini-cli`         | `.gemini/settings.json` | `~/.gemini/settings.json`                                         |
+| Goose              | `goose`              | `.goose/config.yaml`    | `~/.config/goose/config.yaml`                                     |
+| GitHub Copilot CLI | `github-copilot-cli` | `.vscode/mcp.json`      | `~/.copilot/mcp-config.json`                                      |
+| OpenCode           | `opencode`           | `opencode.json`         | `~/.config/opencode/opencode.json`                                |
+| VS Code            | `vscode`             | `.vscode/mcp.json`      | `~/Library/Application Support/Code/User/mcp.json`                |
+| Zed                | `zed`                | `.zed/settings.json`    | `~/Library/Application Support/Zed/settings.json`                 |
 
 **Aliases:** `gemini` → `gemini-cli`, `github-copilot` → `vscode`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",
@@ -31,6 +31,7 @@
     "claude-desktop",
     "codex",
     "cursor",
+    "github-copilot-cli",
     "gemini-cli",
     "goose",
     "opencode",

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -82,6 +82,17 @@ function getConfigPath(
   return agent.configPath;
 }
 
+function getConfigKey(
+  agent: AgentConfig,
+  options: InstallOptions = {},
+): string {
+  if (options.local && agent.localConfigKey) {
+    return agent.localConfigKey;
+  }
+
+  return agent.configKey;
+}
+
 export function installServerForAgent(
   serverName: string,
   serverConfig: McpServerConfig,
@@ -98,16 +109,15 @@ export function installServerForAgent(
     }
 
     const transformedConfig = agent.transformConfig
-      ? agent.transformConfig(serverName, serverConfig)
+      ? agent.transformConfig(serverName, serverConfig, {
+          local: Boolean(options.local),
+        })
       : serverConfig;
 
-    const config = buildConfigWithKey(
-      agent.configKey,
-      serverName,
-      transformedConfig,
-    );
+    const configKey = getConfigKey(agent, options);
+    const config = buildConfigWithKey(configKey, serverName, transformedConfig);
 
-    writeConfig(configPath, config, agent.format, agent.configKey);
+    writeConfig(configPath, config, agent.format, configKey);
 
     return {
       success: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type AgentType =
   | "cursor"
   | "gemini-cli"
   | "goose"
+  | "github-copilot-cli"
   | "opencode"
   | "vscode"
   | "zed";
@@ -29,6 +30,8 @@ export interface AgentConfig {
   projectDetectPaths: string[];
   /** Key in config file where MCP servers are stored (supports dot notation) */
   configKey: string;
+  /** Optional key for project-level config when different from global configKey */
+  localConfigKey?: string;
   /** Config file format */
   format: ConfigFormat;
   /** Supported transport types for this agent */
@@ -38,7 +41,11 @@ export interface AgentConfig {
   /** Function to detect if agent is installed globally */
   detectGlobalInstall: () => Promise<boolean>;
   /** Optional function to transform server config to agent-specific format */
-  transformConfig?: (serverName: string, config: McpServerConfig) => unknown;
+  transformConfig?: (
+    serverName: string,
+    config: McpServerConfig,
+    context?: { local: boolean },
+  ) => unknown;
 }
 
 export type SourceType = "remote" | "package" | "command";

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -21,6 +21,7 @@ import {
   buildAgentSelectionChoices,
 } from "../src/agents.js";
 import type { AgentType } from "../src/types.js";
+import { agentAliases } from "../src/types.js";
 
 let passed = 0;
 let failed = 0;
@@ -59,15 +60,16 @@ function cleanup() {
 // Agent Configuration Tests
 // ============================================
 
-test("getAgentTypes returns all 9 agents", () => {
+test("getAgentTypes returns all 10 agents", () => {
   const types = getAgentTypes();
-  assert.strictEqual(types.length, 9);
+  assert.strictEqual(types.length, 10);
   assert.ok(types.includes("claude-code"));
   assert.ok(types.includes("claude-desktop"));
   assert.ok(types.includes("codex"));
   assert.ok(types.includes("cursor"));
   assert.ok(types.includes("gemini-cli"));
   assert.ok(types.includes("goose"));
+  assert.ok(types.includes("github-copilot-cli"));
   assert.ok(types.includes("opencode"));
   assert.ok(types.includes("vscode"));
   assert.ok(types.includes("zed"));
@@ -105,6 +107,7 @@ test("supportsProjectConfig - returns true for project-capable agents", () => {
   assert.strictEqual(supportsProjectConfig("vscode"), true);
   assert.strictEqual(supportsProjectConfig("opencode"), true);
   assert.strictEqual(supportsProjectConfig("gemini-cli"), true);
+  assert.strictEqual(supportsProjectConfig("github-copilot-cli"), true);
   assert.strictEqual(supportsProjectConfig("codex"), true);
   assert.strictEqual(supportsProjectConfig("zed"), true);
 });
@@ -114,14 +117,15 @@ test("supportsProjectConfig - returns false for global-only agents", () => {
   assert.strictEqual(supportsProjectConfig("goose"), false);
 });
 
-test("getProjectCapableAgents returns 7 agents", () => {
+test("getProjectCapableAgents returns 8 agents", () => {
   const projectAgents = getProjectCapableAgents();
-  assert.strictEqual(projectAgents.length, 7);
+  assert.strictEqual(projectAgents.length, 8);
   assert.ok(projectAgents.includes("claude-code"));
   assert.ok(projectAgents.includes("cursor"));
   assert.ok(projectAgents.includes("vscode"));
   assert.ok(projectAgents.includes("opencode"));
   assert.ok(projectAgents.includes("gemini-cli"));
+  assert.ok(projectAgents.includes("github-copilot-cli"));
   assert.ok(projectAgents.includes("codex"));
   assert.ok(projectAgents.includes("zed"));
 });
@@ -168,6 +172,7 @@ test("detectProjectAgents - detects .vscode directory", () => {
 
   const detected = detectProjectAgents(tempDir);
   assert.ok(detected.includes("vscode"));
+  assert.ok(detected.includes("github-copilot-cli"));
 });
 
 test("detectProjectAgents - detects .mcp.json file (claude-code)", () => {
@@ -233,9 +238,10 @@ test("detectProjectAgents - detects multiple agents", () => {
   writeFileSync(join(tempDir, ".mcp.json"), "{}");
 
   const detected = detectProjectAgents(tempDir);
-  assert.strictEqual(detected.length, 3);
+  assert.strictEqual(detected.length, 4);
   assert.ok(detected.includes("cursor"));
   assert.ok(detected.includes("vscode"));
+  assert.ok(detected.includes("github-copilot-cli"));
   assert.ok(detected.includes("claude-code"));
 });
 


### PR DESCRIPTION
Add a new `github-copilot-cli` agent target

- for local, it installs to`.vscode/mcp.json` (shared with VS Code)
- global installs write Copilot CLI-style `mcpServers` in `~/.copilot/mcp-config.json`