### PR TITLE
fix codex header mapping to http_headers

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -123,11 +123,16 @@ function transformCodexConfig(
   config: McpServerConfig,
 ): unknown {
   if (config.url) {
-    return {
+    const remoteConfig: Record<string, unknown> = {
       type: config.type || "http",
       url: config.url,
-      headers: config.headers,
     };
+
+    if (config.headers && Object.keys(config.headers).length > 0) {
+      remoteConfig.http_headers = config.headers;
+    }
+
+    return remoteConfig;
   }
 
   return {

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -501,6 +501,27 @@ test("E2E: Codex config transformation", () => {
   assert.strictEqual(transformed.url, "https://mcp.example.com/api");
 });
 
+test("E2E: Codex config transformation with headers", () => {
+  const parsed = parseSource("https://mcp.example.com/api");
+  const config = buildServerConfig(parsed, {
+    headers: {
+      Authorization: "Bearer token",
+    },
+  });
+
+  const codexAgent = agents.codex;
+
+  const transformed = codexAgent.transformConfig!("example", config) as Record<
+    string,
+    unknown
+  >;
+
+  assert.deepStrictEqual(transformed.http_headers, {
+    Authorization: "Bearer token",
+  });
+  assert.strictEqual("headers" in transformed, false);
+});
+
 test("E2E: Codex config transformation - local server", () => {
   const parsed = parseSource("mcp-server-postgres");
   const config = buildServerConfig(parsed);


### PR DESCRIPTION
ran into this with codex where headers didn't work but http_headers did

validated checking against codex source
<img width="789" height="512" alt="image" src="https://github.com/user-attachments/assets/6af09dbe-eddc-475d-9828-edd7650092de" />


ai generated pr disclosure