### PR TITLE
fix: claude-desktop only supports stdio transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [1.2.2] - 2026-02-21
 
-fix Goose remote HTTP/SSE header support and simplify header capability handling
+- fix Goose remote HTTP/SSE header support and simplify header capability handling
+- fix Claude Desktop config to only support stdio (remote servers must be added through the Claude Desktop UI)
 
 ## [1.2.1] - 2026-02-17
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -222,6 +222,8 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "mcpServers",
     format: "json",
     supportedTransports: ["stdio"],
+    unsupportedTransportMessage:
+      "Claude Desktop only supports local (stdio) servers via its config file. Add remote servers through Settings → Connectors in the app instead.",
     detectGlobalInstall: async () => {
       return existsSync(join(appSupport, "Claude"));
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -527,11 +527,18 @@ async function main(target: string | undefined, options: Options) {
       .map((a) => agents[a].displayName)
       .join(", ");
 
+    const hints = unsupportedAgents
+      .map((a) => agents[a].unsupportedTransportMessage)
+      .filter(Boolean);
+
     if (options.all) {
       // --all flag: warn but continue with supported agents
       p.log.warn(
         `Skipping agents that don't support ${requiredTransport} transport: ${unsupportedNames}`,
       );
+      for (const hint of hints) {
+        p.log.info(hint!);
+      }
       targetAgents = targetAgents.filter((a) =>
         isTransportSupported(a, requiredTransport),
       );
@@ -545,6 +552,9 @@ async function main(target: string | undefined, options: Options) {
       p.log.error(
         `The following agents don't support ${requiredTransport} transport: ${unsupportedNames}`,
       );
+      for (const hint of hints) {
+        p.log.info(hint!);
+      }
       process.exit(1);
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,8 @@ export interface AgentConfig {
   format: ConfigFormat;
   /** Supported transport types for this agent */
   supportedTransports: ("stdio" | "sse" | "http")[];
+  /** Shown when a user tries to use an unsupported transport */
+  unsupportedTransportMessage?: string;
   /** Function to detect if agent is installed globally */
   detectGlobalInstall: () => Promise<boolean>;
   /** Optional function to transform server config to agent-specific format */

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -333,6 +333,15 @@ test("isTransportSupported - claude-desktop only supports stdio", () => {
   );
 });
 
+test("claude-desktop has unsupportedTransportMessage", () => {
+  const msg = agents["claude-desktop"].unsupportedTransportMessage;
+  assert.ok(msg, "claude-desktop should have an unsupportedTransportMessage");
+  assert.ok(
+    msg.includes("Settings"),
+    "message should mention the Settings UI path",
+  );
+});
+
 // ============================================
 // Agent Config Path Tests
 // ============================================

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -154,6 +154,96 @@ test("E2E CLI: Goose HTTP install with headers", () => {
   });
 });
 
+test("E2E CLI: remote server to claude-desktop errors with custom message", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    ["https://mcp.example.com/mcp", "-a", "claude-desktop", "-y"],
+    projectDir,
+    homeDir,
+  );
+
+  assert.notStrictEqual(result.status, 0, "CLI should exit with non-zero");
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(
+    output,
+    /don't support http transport/,
+    "should report unsupported transport",
+  );
+  assert.match(
+    output,
+    /Settings.*Connectors/,
+    "should include the custom unsupportedTransportMessage",
+  );
+});
+
+test("E2E CLI: --all skips claude-desktop for remote server with custom message", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    ["https://mcp.example.com/mcp", "--all", "-y"],
+    projectDir,
+    homeDir,
+  );
+
+  assert.strictEqual(result.status, 0, "CLI should succeed");
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(
+    output,
+    /Skipping agents.*Claude Desktop/,
+    "should warn about skipping Claude Desktop",
+  );
+  assert.match(
+    output,
+    /Settings.*Connectors/,
+    "should include the custom unsupportedTransportMessage",
+  );
+});
+
+test("E2E CLI: stdio server to claude-desktop succeeds", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "@modelcontextprotocol/server-filesystem",
+      "-a",
+      "claude-desktop",
+      "-y",
+      "--name",
+      "filesystem",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = join(
+    homeDir,
+    "Library",
+    "Application Support",
+    "Claude",
+    "claude_desktop_config.json",
+  );
+  assert.strictEqual(existsSync(configPath), true);
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const servers = saved.mcpServers as Record<string, unknown>;
+  assert.ok(servers.filesystem, "filesystem server should be configured");
+
+  const server = servers.filesystem as Record<string, unknown>;
+  assert.strictEqual(server.command, "npx");
+});
+
 cleanup();
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Problem

`claude-desktop` was configured with `supportedTransports: ["stdio", "http", "sse"]` and `supportsHeaders: true`. This means running:

```
npx add-mcp https://some-remote-server --agent claude-desktop --global
```

...would write a `type: "http"` or `type: "sse"` entry into `claude_desktop_config.json`. Claude Desktop crashes on launch when it encounters either of these — it only supports `stdio` servers (`command` + `args`) in the config file.

## Root cause

Remote MCP support in Claude Desktop is only available through the in-app **Custom Connectors** UI (Settings → Connectors). The `claude_desktop_config.json` file has no support for `url`-based transports.

## Fix

- Set `supportedTransports: ["stdio"]` for `claude-desktop`
- Set `supportsHeaders: false`
- Update tests accordingly, including a dedicated test asserting Claude Desktop is stdio-only

## Verification

Tested manually on macOS by writing both `type: "http"` and `type: "sse"` entries into `claude_desktop_config.json` — both cause Claude Desktop to crash on launch. Removing the entries restores normal operation.