### PR TITLE
docs: add firewall-wrapped stdio command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ npx add-mcp https://mcp.example.com/mcp -g -a claude-code -y
 # Full command with arguments
 npx add-mcp "npx -y @org/mcp-server --flag value"
 
+# Firewall-wrapped stdio command
+npx add-mcp "npx -y mcp-transport-firewall -- npx -y @modelcontextprotocol/server-filesystem /path/to/dir"
+
 # Node.js script
 npx add-mcp "node /path/to/server.js --port 3000"
 


### PR DESCRIPTION
## Summary
- add one small firewall-wrapped stdio command example
- place it next to the existing full-command examples
- keep the rest of the README and CLI behavior unchanged

## Why
dd-mcp already documents package installs and raw stdio commands. This adds one real composition pattern for users who want to place a transport boundary in front of an existing stdio MCP server while still using dd-mcp as the install/config entrypoint.