### PR TITLE
Add Legal Data Hunter — Global Law Research MCP server

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -349,6 +349,26 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.legaldatahunter/mcp",
+      "title": "Legal Data Hunter",
+      "description": "Search 18M+ legal documents worldwide — case law, legislation, and doctrine across 110+ countries. Hybrid semantic + keyword search with filters for court, jurisdiction, language, and date range.",
+      "version": "1.0.0",
+      "websiteUrl": "https://legaldatahunter.com",
+      "repository": {
+        "url": "https://github.com/worldwidelaw/legal-sources",
+        "source": "github"
+      },
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://legaldatahunter.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.mux/mcp",
       "title": "Mux",
       "description": "The official MCP Server for the Mux API",


### PR DESCRIPTION
Adds [Legal Data Hunter](https://legaldatahunter.com) to the registry.

- **URL**: `https://legaldatahunter.com/mcp`
- **Transport**: Streamable HTTP
- **Auth**: OAuth 2.1 (PKCE, dynamic client registration)
- **Coverage**: 17M+ European legal documents — case law, legislation, and doctrine across 100+ countries
- **Tools**: search, get_document, resolve_reference, discover_countries, discover_sources, get_filters

No API key or headers needed — authentication is handled automatically via OAuth on first use.