### PR TITLE
find: stop pinning npm package versions in search installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.8.1] - 2026-04-07
+
+- fix `find` / `search` package installs to stop pinning npm versions and resolve latest implicitly
+
 ## [1.8.0] - 2026-04-05
 
 - add `list` command to display installed MCP servers across detected agents

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/find.ts
+++ b/src/find.ts
@@ -363,9 +363,6 @@ function pickRemote(
 }
 
 function formatPackageTarget(pkg: RegistryPackageDefinition): string {
-  if (pkg.version) {
-    return `${pkg.identifier}@${pkg.version}`;
-  }
   return pkg.identifier;
 }
 

--- a/tests/find.test.ts
+++ b/tests/find.test.ts
@@ -682,7 +682,7 @@ test("buildInstallPlanForEntry returns package target for package-only entry", a
     { yes: true },
   );
   assert.ok(plan);
-  assert.strictEqual(plan?.target, "@sentry/mcp-server@0.25.0");
+  assert.strictEqual(plan?.target, "@sentry/mcp-server");
   assert.strictEqual(plan?.transport, undefined);
   assert.strictEqual(plan?.headers, undefined);
 });


### PR DESCRIPTION
## Summary
- Change `find`/`search` package install planning to use only the npm package identifier.
- Stop appending `@version` from registry metadata so installs implicitly resolve to latest.
- Update `find` unit test expectation for package-only entries.

## Test plan
- [x] `bun run test:unit`