### PR TITLE
Add packageArguments support in buildServerConfig functions

### DIFF
--- a/src/find.ts
+++ b/src/find.ts
@@ -1,5 +1,5 @@
 import * as p from "@clack/prompts";
-import type { TransportType } from "./types.js";
+import type { PackageArgument, TransportType } from "./types.js";
 
 export type RegistryRemoteTransport = "streamable-http" | "sse";
 
@@ -32,6 +32,7 @@ export interface RegistryPackageDefinition {
   transport: {
     type: "stdio";
   };
+  packageArguments?: PackageArgument[];
 }
 
 export interface RegistryServerEntry {
@@ -55,6 +56,7 @@ export interface FindInstallPlan {
   serverName: string;
   transport?: TransportType;
   headers?: Record<string, string>;
+  packageArguments?: PackageArgument[];
 }
 
 export interface PromptField {
@@ -522,6 +524,7 @@ export async function buildInstallPlanForEntry(
     return {
       target: formatPackageTarget(pkg),
       serverName: resolveServerName(entry),
+      packageArguments: pkg.packageArguments,
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { program } from "commander";
 import * as p from "@clack/prompts";
 import chalk from "chalk";
 import { homedir } from "os";
-import type { AgentType, TransportType } from "./types.js";
+import type { AgentType, PackageArgument, TransportType } from "./types.js";
 import { agentAliases } from "./types.js";
 import {
   agents,
@@ -152,6 +152,7 @@ interface Options {
   yes?: boolean;
   all?: boolean;
   gitignore?: boolean;
+  packageArguments?: PackageArgument[];
 }
 
 async function ensureFindRegistriesConfigured(
@@ -440,6 +441,7 @@ async function runFindCommand(
           ([key, value]) => `${key}: ${value}`,
         )
       : options.header,
+    packageArguments: installPlan.packageArguments,
   };
 
   await main(installPlan.target, mergedOptions);
@@ -1285,6 +1287,7 @@ async function main(target: string | undefined, options: Options) {
     transport: resolvedTransport,
     headers: isRemote && hasHeaderValues ? headerResult.headers : undefined,
     env: !isRemote && hasEnvValues ? envResult.env : undefined,
+    packageArguments: options.packageArguments,
   });
 
   // Determine target agents

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -4,6 +4,7 @@ import type {
   AgentType,
   AgentConfig,
   McpServerConfig,
+  PackageArgument,
   ParsedSource,
   TransportType,
 } from "./types.js";
@@ -37,6 +38,8 @@ export interface BuildServerConfigOptions {
   headers?: Record<string, string>;
   /** Environment variables for local stdio servers */
   env?: Record<string, string>;
+  /** Package arguments from server.json spec (appended after package name) */
+  packageArguments?: PackageArgument[];
 }
 
 export interface UpdateGitignoreOptions {
@@ -47,6 +50,27 @@ export interface UpdateGitignoreOptions {
 export interface UpdateGitignoreResult {
   path: string;
   added: string[];
+}
+
+export function resolvePackageArguments(
+  packageArguments: PackageArgument[],
+): string[] {
+  const result: string[] = [];
+  for (const arg of packageArguments) {
+    const resolvedValue = arg.value ?? arg.default;
+    if (arg.type === "positional") {
+      if (resolvedValue) {
+        result.push(resolvedValue);
+      }
+    } else if (arg.type === "named" && arg.name) {
+      if (resolvedValue) {
+        result.push(arg.name, resolvedValue);
+      } else {
+        result.push(arg.name);
+      }
+    }
+  }
+  return result;
 }
 
 export function buildServerConfig(
@@ -82,9 +106,14 @@ export function buildServerConfig(
     return config;
   }
 
+  const extraArgs =
+    options.packageArguments && options.packageArguments.length > 0
+      ? resolvePackageArguments(options.packageArguments)
+      : [];
+
   const config: McpServerConfig = {
     command: "npx",
-    args: ["-y", parsed.value],
+    args: ["-y", parsed.value, ...extraArgs],
   };
 
   if (options.env && Object.keys(options.env).length > 0) {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -59,11 +59,11 @@ export function resolvePackageArguments(
   for (const arg of packageArguments) {
     const resolvedValue = arg.value ?? arg.default;
     if (arg.type === "positional") {
-      if (resolvedValue) {
+      if (resolvedValue && resolvedValue.trim() !== "") {
         result.push(resolvedValue);
       }
     } else if (arg.type === "named" && arg.name) {
-      if (resolvedValue) {
+      if (resolvedValue && resolvedValue.trim() !== "") {
         result.push(arg.name, resolvedValue);
       } else {
         result.push(arg.name);

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,18 @@ export interface ParsedSource {
 
 export type TransportType = "sse" | "http";
 
+export interface PackageArgument {
+  type: "positional" | "named";
+  name?: string;
+  value?: string;
+  valueHint?: string;
+  description?: string;
+  default?: string;
+  isRequired?: boolean;
+  isRepeated?: boolean;
+  choices?: string[];
+}
+
 export interface McpServerConfig {
   /** For remote servers */
   type?: TransportType;

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -20,6 +20,7 @@ import { join } from "node:path";
 import {
   buildServerConfig,
   installServer,
+  resolvePackageArguments,
   updateGitignoreWithPaths,
 } from "../src/installer.js";
 import { agents } from "../src/agents.js";
@@ -157,6 +158,156 @@ test("buildServerConfig - package includes env when provided", () => {
     API_KEY: "secret",
     DATABASE_URL: "postgres://localhost/my-db",
   });
+});
+
+// buildServerConfig tests - packageArguments
+test("buildServerConfig - package with positional packageArguments", () => {
+  const parsed = parseSource("mcp-server-sample");
+  const config = buildServerConfig(parsed, {
+    packageArguments: [
+      { type: "positional", value: "mcp" },
+      { type: "positional", value: "start" },
+    ],
+  });
+
+  assert.strictEqual(config.command, "npx");
+  assert.deepStrictEqual(config.args, [
+    "-y",
+    "mcp-server-sample",
+    "mcp",
+    "start",
+  ]);
+});
+
+test("buildServerConfig - package with named packageArguments", () => {
+  const parsed = parseSource("@modelcontextprotocol/server-postgres");
+  const config = buildServerConfig(parsed, {
+    packageArguments: [{ type: "named", name: "--mode", value: "local" }],
+  });
+
+  assert.strictEqual(config.command, "npx");
+  assert.deepStrictEqual(config.args, [
+    "-y",
+    "@modelcontextprotocol/server-postgres",
+    "--mode",
+    "local",
+  ]);
+});
+
+test("buildServerConfig - package with named packageArguments using default", () => {
+  const parsed = parseSource("@modelcontextprotocol/server-filesystem");
+  const config = buildServerConfig(parsed, {
+    packageArguments: [{ type: "named", name: "--port", default: "3000" }],
+  });
+
+  assert.strictEqual(config.command, "npx");
+  assert.deepStrictEqual(config.args, [
+    "-y",
+    "@modelcontextprotocol/server-filesystem",
+    "--port",
+    "3000",
+  ]);
+});
+
+test("buildServerConfig - package with mixed packageArguments", () => {
+  const parsed = parseSource("mcp-server-sample");
+  const config = buildServerConfig(parsed, {
+    packageArguments: [
+      { type: "positional", value: "mcp" },
+      { type: "named", name: "-t", default: "stdio" },
+    ],
+  });
+
+  assert.strictEqual(config.command, "npx");
+  assert.deepStrictEqual(config.args, [
+    "-y",
+    "mcp-server-sample",
+    "mcp",
+    "-t",
+    "stdio",
+  ]);
+});
+
+test("buildServerConfig - package with named flag (no value)", () => {
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed, {
+    packageArguments: [{ type: "named", name: "--verbose" }],
+  });
+
+  assert.strictEqual(config.command, "npx");
+  assert.deepStrictEqual(config.args, [
+    "-y",
+    "mcp-server-postgres",
+    "--verbose",
+  ]);
+});
+
+test("buildServerConfig - package with empty packageArguments", () => {
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed, {
+    packageArguments: [],
+  });
+
+  assert.strictEqual(config.command, "npx");
+  assert.deepStrictEqual(config.args, ["-y", "mcp-server-postgres"]);
+});
+
+test("buildServerConfig - package with packageArguments and env", () => {
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed, {
+    packageArguments: [{ type: "positional", value: "mcp" }],
+    env: { API_KEY: "secret" },
+  });
+
+  assert.strictEqual(config.command, "npx");
+  assert.deepStrictEqual(config.args, ["-y", "mcp-server-postgres", "mcp"]);
+  assert.deepStrictEqual(config.env, { API_KEY: "secret" });
+});
+
+test("buildServerConfig - packageArguments skips positional without value", () => {
+  const parsed = parseSource("mcp-server-sample");
+  const config = buildServerConfig(parsed, {
+    packageArguments: [
+      { type: "positional", valueHint: "target_dir", isRequired: true },
+      { type: "positional", value: "start" },
+    ],
+  });
+
+  assert.strictEqual(config.command, "npx");
+  assert.deepStrictEqual(config.args, ["-y", "mcp-server-sample", "start"]);
+});
+
+test("buildServerConfig - packageArguments positional uses default when no value", () => {
+  const parsed = parseSource("mcp-server-sample");
+  const config = buildServerConfig(parsed, {
+    packageArguments: [
+      { type: "positional", valueHint: "target_dir", default: "/tmp/path" },
+    ],
+  });
+
+  assert.strictEqual(config.command, "npx");
+  assert.deepStrictEqual(config.args, ["-y", "mcp-server-sample", "/tmp/path"]);
+});
+
+test("buildServerConfig - packageArguments ignored for remote sources", () => {
+  const parsed = parseSource("https://mcp.example.com/api");
+  const config = buildServerConfig(parsed, {
+    packageArguments: [{ type: "positional", value: "mcp" }],
+  });
+
+  assert.strictEqual(config.type, "http");
+  assert.strictEqual(config.url, "https://mcp.example.com/api");
+  assert.strictEqual(config.command, undefined);
+});
+
+test("buildServerConfig - packageArguments ignored for command sources", () => {
+  const parsed = parseSource("node /path/to/server.js");
+  const config = buildServerConfig(parsed, {
+    packageArguments: [{ type: "positional", value: "mcp" }],
+  });
+
+  assert.strictEqual(config.command, "node");
+  assert.deepStrictEqual(config.args, ["/path/to/server.js"]);
 });
 
 // buildServerConfig tests - Command
@@ -597,6 +748,65 @@ test("updateGitignoreWithPaths - appends only new local paths", () => {
     readFileSync(gitignorePath, "utf-8"),
     ".cursor/mcp.json\n.vscode/mcp.json\n",
   );
+});
+
+// resolvePackageArguments tests
+test("resolvePackageArguments - positional with value", () => {
+  const result = resolvePackageArguments([
+    { type: "positional", value: "mcp" },
+    { type: "positional", value: "start" },
+  ]);
+  assert.deepStrictEqual(result, ["mcp", "start"]);
+});
+
+test("resolvePackageArguments - named with value", () => {
+  const result = resolvePackageArguments([
+    { type: "named", name: "--mode", value: "local" },
+  ]);
+  assert.deepStrictEqual(result, ["--mode", "local"]);
+});
+
+test("resolvePackageArguments - named with default (no value)", () => {
+  const result = resolvePackageArguments([
+    { type: "named", name: "--port", default: "3000" },
+  ]);
+  assert.deepStrictEqual(result, ["--port", "3000"]);
+});
+
+test("resolvePackageArguments - named flag without value or default", () => {
+  const result = resolvePackageArguments([
+    { type: "named", name: "--verbose" },
+  ]);
+  assert.deepStrictEqual(result, ["--verbose"]);
+});
+
+test("resolvePackageArguments - value takes precedence over default", () => {
+  const result = resolvePackageArguments([
+    { type: "named", name: "--port", value: "8080", default: "3000" },
+  ]);
+  assert.deepStrictEqual(result, ["--port", "8080"]);
+});
+
+test("resolvePackageArguments - skips positional without value or default", () => {
+  const result = resolvePackageArguments([
+    { type: "positional", valueHint: "target_dir", isRequired: true },
+  ]);
+  assert.deepStrictEqual(result, []);
+});
+
+test("resolvePackageArguments - mixed types", () => {
+  const result = resolvePackageArguments([
+    { type: "positional", value: "mcp" },
+    { type: "named", name: "-t", value: "stdio" },
+    { type: "positional", value: "start" },
+    { type: "named", name: "--verbose" },
+  ]);
+  assert.deepStrictEqual(result, ["mcp", "-t", "stdio", "start", "--verbose"]);
+});
+
+test("resolvePackageArguments - empty array", () => {
+  const result = resolvePackageArguments([]);
+  assert.deepStrictEqual(result, []);
 });
 
 // Cleanup and summary


### PR DESCRIPTION
The [server.json Spec](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/generic-server-json.md) contains `packageArguments`, which allows for executing the stdio servers with arguments.

This is especially useful if the mcp server is part of a cli and is started with a parameter e.g. `mycli start`.

This was not previously supported by add-mcp, instead only the base command (e.g. `mycli`) was executed ignoring the server.json `packageArguments` value.

This pull request implements full support for packageArguments according to spec.
I also added full test coverage for my packageArguments implementation.