### PR TITLE
Add MCP tool auto-approval options

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ npx add-mcp mcp-server-github --all -g -y
 
 # Add generated config files to .gitignore
 npx add-mcp https://mcp.example.com/mcp -a cursor -y --gitignore
+
+# Auto-approve all tools for agents that support it (Codex and Claude Code)
+npx add-mcp "executor mcp" --name executor -a codex -a claude-code --auto-approve
+
+# Auto-approve only selected tools
+npx add-mcp "executor mcp" --name executor -a codex --auto-approve --approve-tool execute
 ```
 
 ### Options
@@ -153,6 +159,8 @@ npx add-mcp https://mcp.example.com/mcp -a cursor -y --gitignore
 | `--type <type>`          | Alias for `--transport`                                                  |
 | `--header <header>`      | HTTP header for remote servers (repeatable, `Key: Value`)                |
 | `--env <env>`            | Env var for local stdio servers (repeatable, `KEY=VALUE`)                |
+| `--auto-approve`         | Auto-approve MCP tool calls for supported agents (Codex and Claude Code) |
+| `--approve-tool <tool>`  | Tool name to auto-approve with `--auto-approve` (repeatable)             |
 | `-n, --name <name>`      | Server name (auto-inferred if not provided)                              |
 | `-y, --yes`              | Skip all confirmation prompts                                            |
 | `--all`                  | Install to all agents                                                    |
@@ -194,14 +202,16 @@ npx add-mcp find github --all --gitignore
 
 ### Options
 
-| Option                | Description                                                              |
-| --------------------- | ------------------------------------------------------------------------ |
-| `-g, --global`        | Install to user directory instead of project                             |
-| `-a, --agent <agent>` | Target specific agents (e.g., `cursor`, `claude-code`). Can be repeated. |
-| `-n, --name <name>`   | Server name override (defaults to the selected catalog entry name)       |
-| `-y, --yes`           | Skip confirmation prompts                                                |
-| `--all`               | Install to all agents                                                    |
-| `--gitignore`         | Add generated config files to `.gitignore`                               |
+| Option                  | Description                                                              |
+| ----------------------- | ------------------------------------------------------------------------ |
+| `-g, --global`          | Install to user directory instead of project                             |
+| `-a, --agent <agent>`   | Target specific agents (e.g., `cursor`, `claude-code`). Can be repeated. |
+| `-n, --name <name>`     | Server name override (defaults to the selected catalog entry name)       |
+| `--auto-approve`        | Auto-approve MCP tool calls for supported agents (Codex and Claude Code) |
+| `--approve-tool <tool>` | Tool name to auto-approve with `--auto-approve` (repeatable)             |
+| `-y, --yes`             | Skip confirmation prompts                                                |
+| `--all`                 | Install to all agents                                                    |
+| `--gitignore`           | Add generated config files to `.gitignore`                               |
 
 Transport for `find`/`search` is inferred from registry metadata. The CLI prefers HTTP remotes when available and only falls back to SSE when HTTP is not available for the selected install context.
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -141,6 +141,23 @@ function transformCodexConfig(
   _serverName: string,
   config: McpServerConfig,
 ): unknown {
+  const addCodexApproval = (target: Record<string, unknown>) => {
+    if (!config.autoApproveTools) return target;
+
+    if (config.autoApproveTools.length === 0) {
+      target.default_tools_approval_mode = "approve";
+      return target;
+    }
+
+    target.tools = Object.fromEntries(
+      config.autoApproveTools.map((tool) => [
+        tool,
+        { approval_mode: "approve" },
+      ]),
+    );
+    return target;
+  };
+
   if (config.url) {
     const remoteConfig: Record<string, unknown> = {
       type: config.type || "http",
@@ -151,14 +168,14 @@ function transformCodexConfig(
       remoteConfig.http_headers = config.headers;
     }
 
-    return remoteConfig;
+    return addCodexApproval(remoteConfig);
   }
 
-  return {
+  return addCodexApproval({
     command: config.command,
     args: config.args || [],
     env: config.env,
-  };
+  });
 }
 
 function transformCursorConfig(

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,8 @@ interface Options {
   type?: string;
   header?: string[];
   env?: string[];
+  autoApprove?: boolean;
+  approveTool?: string[];
   yes?: boolean;
   all?: boolean;
   gitignore?: boolean;
@@ -234,6 +236,25 @@ function extractSubcommandOptionsFromArgv(): Partial<Options> {
     }
     if (arg === "--gitignore") {
       result.gitignore = true;
+      continue;
+    }
+    if (arg === "--auto-approve") {
+      result.autoApprove = true;
+      continue;
+    }
+    if (arg === "--approve-tool") {
+      const tools: string[] = result.approveTool ? [...result.approveTool] : [];
+      let j = i + 1;
+      while (j < argv.length) {
+        const value = argv[j];
+        if (!value || value.startsWith("-")) break;
+        tools.push(value);
+        j += 1;
+      }
+      if (tools.length > 0) {
+        result.approveTool = tools;
+      }
+      i = j - 1;
       continue;
     }
     if ((arg === "-n" || arg === "--name") && argv[i + 1]) {
@@ -390,6 +411,16 @@ program
     collect,
     [],
   )
+  .option(
+    "--auto-approve",
+    "Auto-approve MCP tool calls for agents that support it (Codex and Claude Code)",
+  )
+  .option(
+    "--approve-tool <tool>",
+    "Tool name to auto-approve when --auto-approve is set (repeatable, defaults to all tools)",
+    collect,
+    [],
+  )
   .option("-y, --yes", "Skip confirmation prompts")
   .option("--all", "Install to all agents")
   .option("--gitignore", "Add generated project config files to .gitignore")
@@ -460,6 +491,16 @@ program
     "Server name override (defaults to catalog entry name)",
   )
   .option("-y, --yes", "Skip confirmation prompts")
+  .option(
+    "--auto-approve",
+    "Auto-approve MCP tool calls for agents that support it (Codex and Claude Code)",
+  )
+  .option(
+    "--approve-tool <tool>",
+    "Tool name to auto-approve when --auto-approve is set (repeatable, defaults to all tools)",
+    collect,
+    [],
+  )
   .option("--all", "Install to all agents")
   .option("--gitignore", "Add generated project config files to .gitignore")
   .action(
@@ -484,6 +525,16 @@ program
     "Server name override (defaults to catalog entry name)",
   )
   .option("-y, --yes", "Skip confirmation prompts")
+  .option(
+    "--auto-approve",
+    "Auto-approve MCP tool calls for agents that support it (Codex and Claude Code)",
+  )
+  .option(
+    "--approve-tool <tool>",
+    "Tool name to auto-approve when --auto-approve is set (repeatable, defaults to all tools)",
+    collect,
+    [],
+  )
   .option("--all", "Install to all agents")
   .option("--gitignore", "Add generated project config files to .gitignore")
   .action(
@@ -1258,6 +1309,10 @@ async function main(target: string | undefined, options: Options) {
     );
   }
 
+  const approveTools = [...new Set(options.approveTool ?? [])];
+  const autoApproveTools =
+    options.autoApprove || approveTools.length > 0 ? approveTools : undefined;
+
   // Determine server name
   const serverName = options.name || parsed.inferredName;
   p.log.info(`Server name: ${chalk.cyan(serverName)}`);
@@ -1285,6 +1340,7 @@ async function main(target: string | undefined, options: Options) {
     transport: resolvedTransport,
     headers: isRemote && hasHeaderValues ? headerResult.headers : undefined,
     env: !isRemote && hasEnvValues ? envResult.env : undefined,
+    autoApproveTools,
   });
 
   // Determine target agents
@@ -1555,6 +1611,15 @@ async function main(target: string | undefined, options: Options) {
   const summaryLines: string[] = [];
   summaryLines.push(`${chalk.cyan("Server:")} ${serverName}`);
   summaryLines.push(`${chalk.cyan("Type:")} ${sourceType}`);
+  if (autoApproveTools) {
+    summaryLines.push(
+      `${chalk.cyan("Auto-approve:")} ${
+        autoApproveTools.length === 0
+          ? "All tools"
+          : autoApproveTools.join(", ")
+      }`,
+    );
+  }
 
   // Determine scope display
   const localAgents = targetAgents.filter(

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
 import { join, dirname, isAbsolute, relative, sep } from "path";
 import type {
   AgentType,
@@ -9,6 +10,8 @@ import type {
 } from "./types.js";
 import { agents } from "./agents.js";
 import { writeConfig, buildConfigWithKey } from "./formats/index.js";
+
+const home = homedir();
 
 export interface InstallOptions {
   /** Install to local (project-level) config instead of global */
@@ -37,6 +40,8 @@ export interface BuildServerConfigOptions {
   headers?: Record<string, string>;
   /** Environment variables for local stdio servers */
   env?: Record<string, string>;
+  /** Auto-approve MCP tool calls for agents that support it. Empty means all tools. */
+  autoApproveTools?: string[];
 }
 
 export interface UpdateGitignoreOptions {
@@ -62,6 +67,9 @@ export function buildServerConfig(
     if (options.headers && Object.keys(options.headers).length > 0) {
       config.headers = options.headers;
     }
+    if (options.autoApproveTools) {
+      config.autoApproveTools = options.autoApproveTools;
+    }
 
     return config;
   }
@@ -78,6 +86,9 @@ export function buildServerConfig(
     if (options.env && Object.keys(options.env).length > 0) {
       config.env = options.env;
     }
+    if (options.autoApproveTools) {
+      config.autoApproveTools = options.autoApproveTools;
+    }
 
     return config;
   }
@@ -90,8 +101,100 @@ export function buildServerConfig(
   if (options.env && Object.keys(options.env).length > 0) {
     config.env = options.env;
   }
+  if (options.autoApproveTools) {
+    config.autoApproveTools = options.autoApproveTools;
+  }
 
   return config;
+}
+
+function readJsonObject(filePath: string): Record<string, unknown> {
+  if (!existsSync(filePath)) {
+    return {};
+  }
+  const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as unknown;
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : {};
+}
+
+function writeJsonObject(
+  filePath: string,
+  value: Record<string, unknown>,
+): void {
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
+function addUniqueStrings(existing: unknown, additions: string[]): string[] {
+  const values = Array.isArray(existing)
+    ? existing.filter((value): value is string => typeof value === "string")
+    : [];
+  for (const addition of additions) {
+    if (!values.includes(addition)) {
+      values.push(addition);
+    }
+  }
+  return values;
+}
+
+function claudeAutoApproveRules(serverName: string, tools: string[]): string[] {
+  if (tools.length === 0) {
+    return [`mcp__${serverName}`];
+  }
+  return tools.map((tool) => `mcp__${serverName}__${tool}`);
+}
+
+function getClaudeCodeSettingsPath(options: InstallOptions = {}): string {
+  const local = Boolean(options.local);
+  const cwd = options.cwd || process.cwd();
+  return local
+    ? join(cwd, ".claude", "settings.local.json")
+    : join(home, ".claude", "settings.json");
+}
+
+function installClaudeCodeAutoApproval(
+  serverName: string,
+  tools: string[],
+  options: InstallOptions = {},
+): InstallResult {
+  const settingsPath = getClaudeCodeSettingsPath(options);
+
+  try {
+    const settings = readJsonObject(settingsPath);
+    const permissions =
+      settings.permissions &&
+      typeof settings.permissions === "object" &&
+      !Array.isArray(settings.permissions)
+        ? (settings.permissions as Record<string, unknown>)
+        : {};
+
+    permissions.allow = addUniqueStrings(
+      permissions.allow,
+      claudeAutoApproveRules(serverName, tools),
+    );
+    settings.permissions = permissions;
+    writeJsonObject(settingsPath, settings);
+
+    return {
+      success: true,
+      path: settingsPath,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      path: settingsPath,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
+function stripInternalServerConfig(config: McpServerConfig): McpServerConfig {
+  const { autoApproveTools: _autoApproveTools, ...publicConfig } = config;
+  return publicConfig;
 }
 
 export function updateGitignoreWithPaths(
@@ -205,12 +308,23 @@ export function installServerForAgent(
       ? agent.transformConfig(serverName, serverConfig, {
           local: Boolean(options.local),
         })
-      : serverConfig;
+      : stripInternalServerConfig(serverConfig);
 
     const configKey = getConfigKey(agent, options);
     const config = buildConfigWithKey(configKey, serverName, transformedConfig);
 
     writeConfig(configPath, config, agent.format, configKey);
+
+    if (agentType === "claude-code" && serverConfig.autoApproveTools) {
+      const approvalResult = installClaudeCodeAutoApproval(
+        serverName,
+        serverConfig.autoApproveTools,
+        options,
+      );
+      if (!approvalResult.success) {
+        return approvalResult;
+      }
+    }
 
     return {
       success: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,8 @@ export interface McpServerConfig {
   command?: string;
   args?: string[];
   env?: Record<string, string>;
+  /** Auto-approve MCP tool calls for agents that support it. Empty means all tools. */
+  autoApproveTools?: string[];
 }
 
 export interface ConfigFile {

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -14,6 +14,7 @@ import { join, dirname } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import yaml from "js-yaml";
+import * as TOML from "@iarna/toml";
 
 let passed = 0;
 let failed = 0;
@@ -140,6 +141,78 @@ test("E2E CLI: --gitignore with --global warns and does not write project .gitig
   );
   assert.strictEqual(existsSync(join(projectDir, ".gitignore")), false);
   assert.strictEqual(existsSync(join(homeDir, ".cursor", "mcp.json")), true);
+});
+
+test("E2E CLI: Codex auto-approve selected tool", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "executor mcp",
+      "-a",
+      "codex",
+      "-y",
+      "--name",
+      "executor",
+      "--auto-approve",
+      "--approve-tool",
+      "execute",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = join(projectDir, ".codex", "config.toml");
+  const saved = TOML.parse(readFileSync(configPath, "utf-8")) as Record<
+    string,
+    unknown
+  >;
+  const mcpServers = saved.mcp_servers as Record<string, unknown>;
+  const executor = mcpServers.executor as Record<string, unknown>;
+  const tools = executor.tools as Record<string, unknown>;
+  assert.deepStrictEqual(tools.execute, { approval_mode: "approve" });
+});
+
+test("E2E CLI: Claude Code auto-approve selected tool", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "executor mcp",
+      "-a",
+      "claude-code",
+      "-y",
+      "--name",
+      "executor",
+      "--auto-approve",
+      "--approve-tool",
+      "execute",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const settingsPath = join(projectDir, ".claude", "settings.local.json");
+  const settings = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<
+    string,
+    unknown
+  >;
+  const permissions = settings.permissions as Record<string, unknown>;
+  assert.deepStrictEqual(permissions.allow, ["mcp__executor__execute"]);
 });
 
 test("E2E CLI: find -y without registry config asks to configure registries", () => {
@@ -393,13 +466,24 @@ test("E2E CLI: stdio server to claude-desktop succeeds", () => {
     );
   }
 
-  const configPath = join(
-    homeDir,
-    "Library",
-    "Application Support",
-    "Claude",
-    "claude_desktop_config.json",
-  );
+  const configPath =
+    process.platform === "darwin"
+      ? join(
+          homeDir,
+          "Library",
+          "Application Support",
+          "Claude",
+          "claude_desktop_config.json",
+        )
+      : process.platform === "win32"
+        ? join(
+            homeDir,
+            "AppData",
+            "Roaming",
+            "Claude",
+            "claude_desktop_config.json",
+          )
+        : join(homeDir, ".config", "Claude", "claude_desktop_config.json");
   assert.strictEqual(existsSync(configPath), true);
 
   const saved = JSON.parse(readFileSync(configPath, "utf-8"));

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -736,6 +736,41 @@ test("E2E: Codex config transformation - local server includes env", () => {
   });
 });
 
+test("E2E: Codex config transformation - auto-approve all tools", () => {
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed, {
+    autoApproveTools: [],
+  });
+
+  const codexAgent = agents.codex;
+
+  const transformed = codexAgent.transformConfig!("postgres", config) as Record<
+    string,
+    unknown
+  >;
+
+  assert.strictEqual(transformed.default_tools_approval_mode, "approve");
+});
+
+test("E2E: Codex config transformation - auto-approve selected tools", () => {
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed, {
+    autoApproveTools: ["query", "schema"],
+  });
+
+  const codexAgent = agents.codex;
+
+  const transformed = codexAgent.transformConfig!("postgres", config) as Record<
+    string,
+    unknown
+  >;
+
+  assert.deepStrictEqual(transformed.tools, {
+    query: { approval_mode: "approve" },
+    schema: { approval_mode: "approve" },
+  });
+});
+
 test("E2E: Write TOML config file (Codex format)", () => {
   const tempDir = createTempDir();
   const codexConfigPath = join(tempDir, ".codex", "config.toml");
@@ -761,6 +796,30 @@ test("E2E: Write TOML config file (Codex format)", () => {
   const serverEntry = mcpServers.postgres as Record<string, unknown>;
   assert.strictEqual(serverEntry.command, "npx");
   assert.deepStrictEqual(serverEntry.args, ["-y", "mcp-server-postgres"]);
+});
+
+test("E2E: Write TOML config file with Codex selected tool approval", () => {
+  const tempDir = createTempDir();
+  const codexConfigPath = join(tempDir, ".codex", "config.toml");
+
+  const parsed = parseSource("mcp-server-postgres");
+  const serverConfig = buildServerConfig(parsed, {
+    autoApproveTools: ["query"],
+  });
+
+  const codexAgent = agents.codex;
+  const transformed = codexAgent.transformConfig!("postgres", serverConfig);
+
+  const config = buildConfigWithKey("mcp_servers", "postgres", transformed);
+  writeConfig(codexConfigPath, config, "toml", "mcp_servers");
+
+  assert.strictEqual(existsSync(codexConfigPath), true);
+
+  const savedConfig = readTomlConfig(codexConfigPath);
+  const mcpServers = savedConfig.mcp_servers as Record<string, unknown>;
+  const serverEntry = mcpServers.postgres as Record<string, unknown>;
+  const tools = serverEntry.tools as Record<string, unknown>;
+  assert.deepStrictEqual(tools.query, { approval_mode: "approve" });
 });
 
 // ============================================

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -485,6 +485,54 @@ test("installServer - cline extension global uses VS Code global storage path", 
   }
 });
 
+test("installServer - claude-code local auto-approval writes settings.local.json", () => {
+  const tempDir = createTempDir();
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed, {
+    autoApproveTools: ["query"],
+  });
+
+  const results = installServer("postgres", config, ["claude-code"], {
+    routing: new Map<AgentType, "local" | "global">([["claude-code", "local"]]),
+    cwd: tempDir,
+  });
+
+  const result = results.get("claude-code");
+  assert.ok(result?.success);
+
+  const mcpConfig = readJsonConfig(join(tempDir, ".mcp.json"));
+  const mcpServers = mcpConfig.mcpServers as Record<string, unknown>;
+  assert.ok(mcpServers.postgres);
+
+  const settings = readJsonConfig(
+    join(tempDir, ".claude", "settings.local.json"),
+  );
+  const permissions = settings.permissions as Record<string, unknown>;
+  assert.deepStrictEqual(permissions.allow, ["mcp__postgres__query"]);
+});
+
+test("installServer - claude-code auto-approval all tools uses server rule", () => {
+  const tempDir = createTempDir();
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed, {
+    autoApproveTools: [],
+  });
+
+  const results = installServer("postgres", config, ["claude-code"], {
+    routing: new Map<AgentType, "local" | "global">([["claude-code", "local"]]),
+    cwd: tempDir,
+  });
+
+  const result = results.get("claude-code");
+  assert.ok(result?.success);
+
+  const settings = readJsonConfig(
+    join(tempDir, ".claude", "settings.local.json"),
+  );
+  const permissions = settings.permissions as Record<string, unknown>;
+  assert.deepStrictEqual(permissions.allow, ["mcp__postgres"]);
+});
+
 test("installServer - mcporter local writes config/mcporter.json", () => {
   const tempDir = createTempDir();
   const parsed = parseSource("mcp-server-postgres");


### PR DESCRIPTION
Draft PR from my agent, validated it does work, will mark as ready once i've reviewed

===

## What changed

- Adds `--auto-approve` and repeatable `--approve-tool <tool>` options.
- Emits Codex MCP approval config for all tools or selected tools.
- Writes Claude Code permission allow rules for project/global settings while keeping the MCP server config clean.
- Documents the new options and adds unit/e2e coverage.

## Why

Some MCP servers already handle approval internally, so users need a way to install them with agent-level MCP approval preconfigured instead of manually editing Codex or Claude Code settings after installation.

## Validation

- `npm run typecheck`
- `npm test`
- Verified generated Codex config with real `codex exec`: `mcp_servers.executor.tools.execute.approval_mode = "approve"` allowed `executor.execute` to return `4` without full bypass.
- Verified generated Claude Code config with real `claude -p`: `.claude/settings.local.json` allowed `mcp__executor__execute`, and the tool returned `4`.
