### PR TITLE
add Zencoder / Zenflow agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ MCP servers can be installed to any of these agents:
 | OpenCode               | `opencode`           | `opencode.json`         | `~/.config/opencode/opencode.json`                                                                              |
 | VS Code                | `vscode`             | `.vscode/mcp.json`      | `~/Library/Application Support/Code/User/mcp.json`                                                              |
 | Zed                    | `zed`                | `.zed/settings.json`    | `~/Library/Application Support/Zed/settings.json`                                                               |
+| Zencoder / Zenflow     | `zencoder`           | `.zencoder/settings.json` | `~/.zencoder/settings.json`                                                                                   |
 
-**Aliases:** `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`
+**Aliases:** `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `zenflow` → `zencoder`
 
 ## Installation Scope
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "mcporter",
     "opencode",
     "vscode",
-    "zed"
+    "zed",
+    "zencoder",
+    "zenflow"
   ],
   "repository": {
     "type": "git",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -511,6 +511,20 @@ export const agents: Record<AgentType, AgentConfig> = {
     },
     transformConfig: transformZedConfig,
   },
+
+  zencoder: {
+    name: "zencoder",
+    displayName: "Zencoder / Zenflow",
+    configPath: join(home, ".zencoder", "settings.json"),
+    localConfigPath: ".zencoder/settings.json",
+    projectDetectPaths: [".zencoder"],
+    configKey: "mcpServers",
+    format: "json",
+    supportedTransports: ["stdio", "http", "sse"],
+    detectGlobalInstall: async () => {
+      return existsSync(join(home, ".zencoder"));
+    },
+  },
 };
 
 export function getAgentTypes(): AgentType[] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,12 +12,14 @@ export type AgentType =
   | "mcporter"
   | "opencode"
   | "vscode"
-  | "zed";
+  | "zed"
+  | "zencoder";
 
 export const agentAliases: Record<string, AgentType> = {
   "cline-vscode": "cline",
   gemini: "gemini-cli",
   "github-copilot": "vscode",
+  zenflow: "zencoder",
 };
 
 export type ConfigFormat = "json" | "yaml" | "toml";

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -60,9 +60,9 @@ function cleanup() {
 // Agent Configuration Tests
 // ============================================
 
-test("getAgentTypes returns all 14 agents", () => {
+test("getAgentTypes returns all 15 agents", () => {
   const types = getAgentTypes();
-  assert.strictEqual(types.length, 14);
+  assert.strictEqual(types.length, 15);
   assert.ok(types.includes("antigravity"));
   assert.ok(types.includes("cline"));
   assert.ok(types.includes("cline-cli"));
@@ -77,6 +77,7 @@ test("getAgentTypes returns all 14 agents", () => {
   assert.ok(types.includes("opencode"));
   assert.ok(types.includes("vscode"));
   assert.ok(types.includes("zed"));
+  assert.ok(types.includes("zencoder"));
 });
 
 test("All agents have required properties", () => {
@@ -124,9 +125,13 @@ test("supportsProjectConfig - returns false for global-only agents", () => {
   assert.strictEqual(supportsProjectConfig("goose"), false);
 });
 
-test("getProjectCapableAgents returns 9 agents", () => {
+test("supportsProjectConfig - returns true for zencoder", () => {
+  assert.strictEqual(supportsProjectConfig("zencoder"), true);
+});
+
+test("getProjectCapableAgents returns 10 agents", () => {
   const projectAgents = getProjectCapableAgents();
-  assert.strictEqual(projectAgents.length, 9);
+  assert.strictEqual(projectAgents.length, 10);
   assert.ok(projectAgents.includes("claude-code"));
   assert.ok(projectAgents.includes("cursor"));
   assert.ok(projectAgents.includes("vscode"));
@@ -136,6 +141,7 @@ test("getProjectCapableAgents returns 9 agents", () => {
   assert.ok(projectAgents.includes("mcporter"));
   assert.ok(projectAgents.includes("codex"));
   assert.ok(projectAgents.includes("zed"));
+  assert.ok(projectAgents.includes("zencoder"));
 });
 
 test("getGlobalOnlyAgents returns 5 agents", () => {
@@ -242,6 +248,14 @@ test("detectProjectAgents - detects .zed directory", () => {
   assert.ok(detected.includes("zed"));
 });
 
+test("detectProjectAgents - detects .zencoder directory", () => {
+  const tempDir = createTempDir();
+  mkdirSync(join(tempDir, ".zencoder"));
+
+  const detected = detectProjectAgents(tempDir);
+  assert.ok(detected.includes("zencoder"));
+});
+
 test("detectProjectAgents - detects config/mcporter.json", () => {
   const tempDir = createTempDir();
   mkdirSync(join(tempDir, "config"), { recursive: true });
@@ -308,6 +322,7 @@ test("isTransportSupported - most agents support http", () => {
     "opencode",
     "vscode",
     "zed",
+    "zencoder",
   ];
 
   for (const type of httpAgents) {
@@ -334,6 +349,7 @@ test("isTransportSupported - most agents support sse", () => {
     "opencode",
     "vscode",
     "zed",
+    "zencoder",
   ];
 
   for (const type of sseAgents) {


### PR DESCRIPTION
## Summary

- Adds support for the Zencoder / Zenflow agent family, which reads `~/.zencoder/settings.json` (machine-wide) and `.zencoder/settings.json` (project-level, overrides global) per the [Zencoder docs](https://docs.zencoder.ai/).
- Adds `zenflow` as an alias for `zencoder` so the CLI accepts either product name.
- Updates tests, README supported-agents table, and the keyword list.

## Suggested changelog entry

> add support for Zencoder / Zenflow (`~/.zencoder/settings.json`), aliased as `zenflow`

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test:unit` (counts updated to 15 total / 10 project-capable / 5 global-only)
- [x] Smoke: `npx tsx src/index.ts -a zencoder -y https://mcp.context7.com/mcp` writes `.zencoder/settings.json`
- [x] Smoke: same with `-a zenflow` resolves through the alias