### PR TITLE
chore: release v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## [1.9.0] - 2026-04-08
+## [1.9.0] - 2026-05-21
 
 - prompt for `${VAR}` template values in `--env`, `--header`, and `--args` flags during interactive mode (skipped optional keys are omitted from written config)
 - prompt for package environment variables, headers, and registry `packageArguments` during `find` search installs (named flags preserved as `flag` + `value` argv pairs; positional order preserved; `-y` substitutes `${VAR}` with placeholders)
+- fix `find` package installs to align argv ordering with registry `packageArguments`
+- allow `pypi` `registryType` in registry entries used by `find`/`search`
 
 ## [1.8.1] - 2026-04-07
 


### PR DESCRIPTION
## Summary

Release v1.9.0. `package.json` is already at 1.9.0 from prior in-flight work; this PR just dates the existing CHANGELOG entry and folds in the two user-facing fixes that landed on main since the entry was written.

### Shipping in 1.9.0

- `feat(template)` prompt for `${VAR}` template values in `--env`, `--header`, and `--args` flags during interactive mode
- `feat(find)` prompt for env vars, headers, and registry `packageArguments` during search installs
- `fix(find)` align package argv with registry `packageArguments` (d8b2c08)
- `fix(registry)` allow `pypi` `registryType` in registry entries used by find/search (b6077b5)

### Out of scope

The secure-publishing pipeline merged in #37 is internal-only (no user-visible behaviour change) and intentionally not in the CHANGELOG. This release is the first one that ships via that pipeline.

## Test plan

- [x] CI green on the PR.
- [ ] After merge, draft GitHub Release `v1.9.0` and let `release.yml` stage publish.
- [ ] `npm stage view add-mcp` to inspect the staged tarball.
- [ ] `npm stage approve add-mcp` with WebAuthn.
- [ ] `npm audit signatures add-mcp@1.9.0` to confirm provenance.

Made with [Cursor](https://cursor.com)