### PR TITLE
fix(test): make claude-desktop e2e test platform-aware + expand ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,8 @@ jobs:
       - name: Type check
         run: bun run typecheck
 
-      - name: Run unit tests
-        run: |
-          bun run tsx tests/source-parser.test.ts
-          bun run tsx tests/installer.test.ts
-
-      - name: Run e2e tests
-        run: bun run tsx tests/e2e/install.test.ts
+      - name: Run tests
+        run: bun run test
 
       - name: Build
         run: bun run build

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -67,6 +67,23 @@ function runCli(args: string[], cwd: string, homeDir: string) {
   });
 }
 
+function claudeDesktopConfigPath(homeDir: string): string {
+  if (process.platform === "darwin") {
+    return join(
+      homeDir,
+      "Library",
+      "Application Support",
+      "Claude",
+      "claude_desktop_config.json",
+    );
+  }
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA || join(homeDir, "AppData", "Roaming");
+    return join(appData, "Claude", "claude_desktop_config.json");
+  }
+  return join(homeDir, ".config", "Claude", "claude_desktop_config.json");
+}
+
 function seedFindRegistries(homeDir: string) {
   const configPath = join(homeDir, ".config", "add-mcp", "config.json");
   mkdirSync(dirname(configPath), { recursive: true });
@@ -393,13 +410,7 @@ test("E2E CLI: stdio server to claude-desktop succeeds", () => {
     );
   }
 
-  const configPath = join(
-    homeDir,
-    "Library",
-    "Application Support",
-    "Claude",
-    "claude_desktop_config.json",
-  );
+  const configPath = claudeDesktopConfigPath(homeDir);
   assert.strictEqual(existsSync(configPath), true);
 
   const saved = JSON.parse(readFileSync(configPath, "utf-8"));


### PR DESCRIPTION
## Why

Cutting v1.9.0 via the new release pipeline (workflow run [26249063170](https://github.com/neon-solutions/add-mcp/actions/runs/26249063170)) failed at the test step — \`E2E CLI: stdio server to claude-desktop succeeds\` hardcoded the macOS Claude Desktop config path (\`Library/Application Support/Claude/...\`). On Ubuntu runners the CLI correctly writes to \`\$XDG_CONFIG_HOME/Claude/\` so the test's \`existsSync\` returned \`false\`. Latent bug that only ever ran on macOS.

The bug never showed up in PR CI because \`ci.yml\` was running a hand-picked subset (\`source-parser\` + \`installer\` + \`install.e2e\`), not the full suite that includes \`cli.e2e\`.

## What

- **\`tests/e2e/cli.test.ts\`** — extract a \`claudeDesktopConfigPath(homeDir)\` helper that branches on \`process.platform\` (darwin/win32/linux), mirroring the resolution logic in \`src/agents.ts\`. The failing test now uses it.
- **\`.github/workflows/ci.yml\`** — replace the hand-picked test list with \`bun run test\` so PR CI now exercises the same suite as \`release.yml\`. Future platform-specific test bugs get caught at PR time, not release time.

Not a user-facing change; no CHANGELOG.

## Test plan

- [x] \`bun run typecheck\` green.
- [x] \`bun run test\` green locally (macOS) — 28/28 in cli.e2e.
- [ ] PR CI green on Ubuntu runner (this is the actual signal).

## Follow-up

Once this is in, delete the failed \`v1.9.0\` GitHub Release + tag and re-cut from the new \`main\` HEAD.

Made with [Cursor](https://cursor.com)