### PR TITLE
fix: surface shell-expansion gotcha for --header and --env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [1.9.1] - 2026-05-21
 
+- reject `--env "KEY="` with empty value (previously silently written to agent config, breaking the MCP server at runtime); error message now hints at shell expansion when a `${VAR}` was likely eaten
 - hint at shell expansion in the `--header` error message when a value is empty (`--header "Key: ${UNSET}"` after the shell ate the placeholder) — suggests using single quotes to pass the `${VAR}` template literally
+- option help text for `--header`, `--env`, and `--args` now mentions the single-quote requirement so the shell does not expand `${VAR}` placeholders
 
 ## [1.9.0] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.9.1] - 2026-05-21
+
+- hint at shell expansion in the `--header` error message when a value is empty (`--header "Key: ${UNSET}"` after the shell ate the placeholder) — suggests using single quotes to pass the `${VAR}` template literally
+
 ## [1.9.0] - 2026-05-21
 
 - prompt for `${VAR}` template values in `--env`, `--header`, and `--args` flags during interactive mode (skipped optional keys are omitted from written config)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -329,12 +329,15 @@ interface ParsedHeadersResult {
   invalid: string[];
 }
 
-function looksLikeEatenShellVar(invalidEntries: string[]): boolean {
+function looksLikeEatenShellVar(
+  invalidEntries: string[],
+  separator: string,
+): boolean {
   for (const entry of invalidEntries) {
-    const colonIndex = entry.indexOf(":");
-    if (colonIndex <= 0) continue;
-    const key = entry.slice(0, colonIndex).trim();
-    const value = entry.slice(colonIndex + 1).trim();
+    const separatorIndex = entry.indexOf(separator);
+    if (separatorIndex <= 0) continue;
+    const key = entry.slice(0, separatorIndex).trim();
+    const value = entry.slice(separatorIndex + 1).trim();
     if (key && !value) return true;
   }
   return false;
@@ -382,9 +385,9 @@ function parseEnv(values: string[]): ParsedEnvResult {
     }
 
     const key = entry.slice(0, separatorIndex).trim();
-    const value = entry.slice(separatorIndex + 1);
+    const value = entry.slice(separatorIndex + 1).trim();
 
-    if (!key) {
+    if (!key || !value) {
       invalid.push(entry);
       continue;
     }
@@ -428,19 +431,19 @@ program
   .option("--type <type>", "Alias for --transport")
   .option(
     "--header <header>",
-    "HTTP header for remote servers (repeatable, 'Key: Value'). Placeholders ${VAR} prompt interactively when not using --yes.",
+    "HTTP header for remote servers (repeatable, 'Key: Value'). Placeholders ${VAR} prompt interactively when not using --yes. Use single quotes so your shell does not expand the ${VAR}.",
     collect,
     [],
   )
   .option(
     "--env <env>",
-    "Environment variable for local stdio servers (repeatable, 'KEY=VALUE'). Placeholders ${VAR} prompt interactively when not using --yes.",
+    "Environment variable for local stdio servers (repeatable, 'KEY=VALUE'). Placeholders ${VAR} prompt interactively when not using --yes. Use single quotes so your shell does not expand the ${VAR}.",
     collect,
     [],
   )
   .option(
     "--args <arg>",
-    "Argument for local stdio servers (repeatable). Placeholders ${VAR} prompt interactively when not using --yes.",
+    "Argument for local stdio servers (repeatable). Placeholders ${VAR} prompt interactively when not using --yes. Use single quotes so your shell does not expand the ${VAR}.",
     collect,
     [],
   )
@@ -1287,7 +1290,7 @@ async function main(target: string | undefined, options: Options) {
   const headerValues = options.header ?? [];
   const headerResult = parseHeaders(headerValues);
   if (headerResult.invalid.length > 0) {
-    const hint = looksLikeEatenShellVar(headerResult.invalid)
+    const hint = looksLikeEatenShellVar(headerResult.invalid, ":")
       ? " (looks like your shell expanded a ${VAR} to an empty string; use single quotes: --header 'Key: ${VAR}' to pass the template literally)"
       : "";
     p.log.error(
@@ -1305,8 +1308,11 @@ async function main(target: string | undefined, options: Options) {
   const envValues = options.env ?? [];
   const envResult = parseEnv(envValues);
   if (envResult.invalid.length > 0) {
+    const hint = looksLikeEatenShellVar(envResult.invalid, "=")
+      ? " (looks like your shell expanded a ${VAR} to an empty string; use single quotes: --env 'KEY=${VAR}' to pass the template literally)"
+      : "";
     p.log.error(
-      `Invalid --env value(s): ${envResult.invalid.join(", ")}. Use "KEY=VALUE" format.`,
+      `Invalid --env value(s): ${envResult.invalid.join(", ")}. Use "KEY=VALUE" format.${hint}`,
     );
     process.exit(1);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -329,6 +329,17 @@ interface ParsedHeadersResult {
   invalid: string[];
 }
 
+function looksLikeEatenShellVar(invalidEntries: string[]): boolean {
+  for (const entry of invalidEntries) {
+    const colonIndex = entry.indexOf(":");
+    if (colonIndex <= 0) continue;
+    const key = entry.slice(0, colonIndex).trim();
+    const value = entry.slice(colonIndex + 1).trim();
+    if (key && !value) return true;
+  }
+  return false;
+}
+
 function parseHeaders(values: string[]): ParsedHeadersResult {
   const headers: Record<string, string> = {};
   const invalid: string[] = [];
@@ -1276,8 +1287,11 @@ async function main(target: string | undefined, options: Options) {
   const headerValues = options.header ?? [];
   const headerResult = parseHeaders(headerValues);
   if (headerResult.invalid.length > 0) {
+    const hint = looksLikeEatenShellVar(headerResult.invalid)
+      ? " (looks like your shell expanded a ${VAR} to an empty string; use single quotes: --header 'Key: ${VAR}' to pass the template literally)"
+      : "";
     p.log.error(
-      `Invalid --header value(s): ${headerResult.invalid.join(", ")}. Use "Key: Value" format.`,
+      `Invalid --header value(s): ${headerResult.invalid.join(", ")}. Use "Key: Value" format.${hint}`,
     );
     process.exit(1);
   }

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -584,6 +584,41 @@ test("E2E CLI: invalid --env format exits with error", () => {
   assert.match(output, /Use "KEY=VALUE" format\./);
 });
 
+test("E2E CLI: --header with empty value hints at shell expansion", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    ["https://mcp.example.com/mcp", "-y", "--header", "Authorization: "],
+    projectDir,
+    homeDir,
+  );
+
+  assert.notStrictEqual(result.status, 0, "CLI should exit with non-zero");
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /Invalid --header value\(s\)/);
+  assert.match(output, /single quotes/);
+  assert.match(output, /\$\{VAR\}/);
+});
+
+test("E2E CLI: --header with no colon does not show shell-expansion hint", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    ["https://mcp.example.com/mcp", "-y", "--header", "no-colon-here"],
+    projectDir,
+    homeDir,
+  );
+
+  assert.notStrictEqual(result.status, 0, "CLI should exit with non-zero");
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /Invalid --header value\(s\)/);
+  assert.doesNotMatch(output, /single quotes/);
+});
+
 test("E2E CLI: remote install with --env warns and succeeds", () => {
   const projectDir = createTempDir();
   const homeDir = createTempDir();

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -602,6 +602,55 @@ test("E2E CLI: --header with empty value hints at shell expansion", () => {
   assert.match(output, /\$\{VAR\}/);
 });
 
+test("E2E CLI: --env with empty value hints at shell expansion", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "@modelcontextprotocol/server-filesystem",
+      "-a",
+      "cursor",
+      "-y",
+      "--env",
+      "API_KEY=",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  assert.notStrictEqual(result.status, 0, "CLI should exit with non-zero");
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /Invalid --env value\(s\)/);
+  assert.match(output, /single quotes/);
+  assert.match(output, /\$\{VAR\}/);
+});
+
+test("E2E CLI: --env with no equals does not show shell-expansion hint", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "@modelcontextprotocol/server-filesystem",
+      "-a",
+      "cursor",
+      "-y",
+      "--env",
+      "no-equals-here",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  assert.notStrictEqual(result.status, 0, "CLI should exit with non-zero");
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /Invalid --env value\(s\)/);
+  assert.doesNotMatch(output, /single quotes/);
+});
+
 test("E2E CLI: --header with no colon does not show shell-expansion hint", () => {
   const projectDir = createTempDir();
   const homeDir = createTempDir();


### PR DESCRIPTION
## Why

If you run \`npx add-mcp@latest <url> --header \"Authorization: \${API_KEY}\"\` (double quotes) and \`\$API_KEY\` is unset, zsh/bash expand the placeholder to an empty string before the CLI ever sees it. The CLI then reports a generic \"Use \\\"Key: Value\\\" format\" error that doesn't explain the shell expansion. Worse, the equivalent \`--env \"API_KEY=\${UNSET}\"\` was *silently accepted* and written to the agent config as \`API_KEY=\"\"\`, causing the MCP server to boot with an empty auth value and fail opaquely at runtime.

Hit this footgun firsthand while smoke-testing the v1.9.0 release.

## What

- **\`--header\`** \u2014 already errors on empty value; now appends a hint pointing at single-quote literal \`\${VAR}\` passthrough when the invalid entry has the shell-eaten fingerprint (key + separator + empty value).
- **\`--env\`** \u2014 now rejects empty values too (previously silently accepted), with the same shell-expansion hint when the value is empty.
- **\`--args\`** \u2014 intentionally untouched. Positional arguments can legitimately be empty strings, so silent acceptance is more correct than an error.
- **Option help text** for \`--header\`, \`--env\`, and \`--args\` now mentions the single-quote requirement so \`npx add-mcp --help\` surfaces the gotcha upfront.

Before:
\`\`\`
Invalid --header value(s): Authorization: . Use \"Key: Value\" format.
\`\`\`

After:
\`\`\`
Invalid --header value(s): Authorization: . Use \"Key: Value\" format. (looks like your shell expanded a \${VAR} to an empty string; use single quotes: --header 'Key: \${VAR}' to pass the template literally)
\`\`\`

## Test plan

- [x] \`E2E CLI: --header with empty value hints at shell expansion\` \u2014 hint path for --header
- [x] \`E2E CLI: --header with no colon does not show shell-expansion hint\` \u2014 no-false-positive for --header
- [x] \`E2E CLI: --env with empty value hints at shell expansion\` \u2014 hint path for --env
- [x] \`E2E CLI: --env with no equals does not show shell-expansion hint\` \u2014 no-false-positive for --env
- [x] \`bun run test\` green locally (32/32 in cli.e2e).
- [x] \`bun run typecheck\` green.
- [ ] PR CI green on Ubuntu.

## Release

Bumps to \`1.9.1\` with a CHANGELOG entry covering all three changes.