### PR TITLE
feat(lib): add programmatic API for detect / upsert / remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.10.0] - 2026-05-21
+
+- expose programmatic API
+
 ## [1.9.1] - 2026-05-21
 
 - reject `--env "KEY="` with empty value (previously silently written to agent config, breaking the MCP server at runtime); error message now hints at shell expansion when a `${VAR}` was likely eaten

--- a/README.md
+++ b/README.md
@@ -359,6 +359,47 @@ npx add-mcp sync -g -y
 
 `unify` is an alias for `sync`.
 
+## Programmatic API
+
+```ts
+import {
+  detectProjectAgents,
+  detectGlobalAgents,
+  upsertServer,
+  removeServer,
+  listInstalledServers,
+} from "add-mcp";
+
+const project = detectProjectAgents("/path/to/project");
+const global = await detectGlobalAgents();
+
+// Remote server
+upsertServer(
+  "claude-code",
+  "example",
+  { type: "http", url: "https://mcp.example.com/api" },
+  { local: true, cwd: "/path/to/project" },
+);
+
+// Stdio (npm package)
+upsertServer("claude-code", "postgres", {
+  command: "npx",
+  args: ["-y", "@modelcontextprotocol/server-postgres"],
+});
+
+const projectServers = await listInstalledServers({
+  cwd: "/path/to/project",
+});
+const globalServers = await listInstalledServers({ global: true });
+
+removeServer("claude-code", "example", {
+  local: true,
+  cwd: "/path/to/project",
+});
+```
+
+`upsertServer` and `removeServer` return `{ success, path, error? }` rather than throwing.
+
 ## Troubleshooting
 
 ### Server not loading

--- a/package.json
+++ b/package.json
@@ -1,10 +1,19 @@
 {
   "name": "add-mcp",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",
   "type": "module",
+  "main": "./dist/lib.js",
+  "types": "./dist/lib.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/lib.d.ts",
+      "import": "./dist/lib.js"
+    },
+    "./package.json": "./package.json"
+  },
   "bin": {
     "add-mcp": "dist/index.js"
   },
@@ -14,10 +23,10 @@
   ],
   "scripts": {
     "fmt": "prettier --write .",
-    "build": "tsup src/index.ts --format esm --dts --clean",
+    "build": "tsup src/index.ts src/lib.ts --format esm --dts --clean",
     "dev": "tsx src/index.ts",
-    "test": "tsx tests/source-parser.test.ts && tsx tests/agents.test.ts && tsx tests/config.test.ts && tsx tests/installer.test.ts && tsx tests/find.test.ts && tsx tests/package-arguments.test.ts && tsx tests/template.test.ts && tsx tests/reader.test.ts && tsx tests/formats-remove.test.ts && tsx tests/e2e/install.test.ts && tsx tests/e2e/cli.test.ts",
-    "test:unit": "tsx tests/source-parser.test.ts && tsx tests/agents.test.ts && tsx tests/config.test.ts && tsx tests/installer.test.ts && tsx tests/find.test.ts && tsx tests/package-arguments.test.ts && tsx tests/template.test.ts && tsx tests/reader.test.ts && tsx tests/formats-remove.test.ts",
+    "test": "tsx tests/source-parser.test.ts && tsx tests/agents.test.ts && tsx tests/config.test.ts && tsx tests/installer.test.ts && tsx tests/find.test.ts && tsx tests/package-arguments.test.ts && tsx tests/template.test.ts && tsx tests/reader.test.ts && tsx tests/formats-remove.test.ts && tsx tests/lib.test.ts && tsx tests/e2e/install.test.ts && tsx tests/e2e/cli.test.ts",
+    "test:unit": "tsx tests/source-parser.test.ts && tsx tests/agents.test.ts && tsx tests/config.test.ts && tsx tests/installer.test.ts && tsx tests/find.test.ts && tsx tests/package-arguments.test.ts && tsx tests/template.test.ts && tsx tests/reader.test.ts && tsx tests/formats-remove.test.ts && tsx tests/lib.test.ts",
     "registry:sort": "tsx scripts/sort-registry.ts",
     "registry:verify": "tsx scripts/verify-registry.ts",
     "test:e2e": "tsx tests/e2e/install.test.ts && tsx tests/e2e/cli.test.ts",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -551,7 +551,7 @@ export function detectProjectAgents(cwd?: string): AgentType[] {
   return detected;
 }
 
-export async function detectAllGlobalAgents(): Promise<AgentType[]> {
+export async function detectGlobalAgents(): Promise<AgentType[]> {
   const detected: AgentType[] = [];
 
   for (const [type, config] of Object.entries(agents)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
   getAgentTypes,
   isTransportSupported,
   detectProjectAgents,
-  detectAllGlobalAgents,
+  detectGlobalAgents,
   supportsProjectConfig,
   getProjectCapableAgents,
   buildAgentSelectionChoices,
@@ -36,7 +36,7 @@ import {
   updateGitignoreWithPaths,
 } from "./installer.js";
 import {
-  gatherInstalledServers,
+  listInstalledServers,
   findMatchingServers,
   extractServerIdentity,
   type AgentServers,
@@ -629,7 +629,7 @@ async function runListCommand(options: Options): Promise<void> {
 
   const explicitAgents = resolveAgentFlags(options.agent);
 
-  const agentServersList = await gatherInstalledServers({
+  const agentServersList = await listInstalledServers({
     global: options.global,
     agents: explicitAgents.length > 0 ? explicitAgents : undefined,
   });
@@ -683,7 +683,7 @@ async function runRemoveCommand(
 
   const explicitAgents = resolveAgentFlags(options.agent);
 
-  const agentServersList = await gatherInstalledServers({
+  const agentServersList = await listInstalledServers({
     global: options.global,
     agents: explicitAgents.length > 0 ? explicitAgents : undefined,
   });
@@ -895,7 +895,7 @@ async function runSyncCommand(options: Options): Promise<void> {
   showLogo();
   console.log();
 
-  const agentServersList = await gatherInstalledServers({
+  const agentServersList = await listInstalledServers({
     global: options.global,
   });
 
@@ -1474,7 +1474,7 @@ async function main(target: string | undefined, options: Options) {
 
     if (options.global) {
       // Global mode: detect all globally installed agents
-      detectedAgents = await detectAllGlobalAgents();
+      detectedAgents = await detectGlobalAgents();
       for (const agent of detectedAgents) {
         agentRouting.set(agent, "global");
       }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,127 @@
+import { existsSync } from "fs";
+import type { AgentType, McpServerConfig } from "./types.js";
+import { agents } from "./agents.js";
+import {
+  getConfigPath,
+  getConfigKey,
+  installServerForAgent,
+  type InstallOptions,
+  type InstallResult,
+} from "./installer.js";
+import {
+  readConfig,
+  removeServerFromConfig,
+  getNestedValue,
+} from "./formats/index.js";
+
+export {
+  agents,
+  detectProjectAgents,
+  detectGlobalAgents,
+  getAgentTypes,
+} from "./agents.js";
+
+export {
+  type InstallOptions,
+  type InstallResult,
+} from "./installer.js";
+
+export {
+  listInstalledServers,
+  type AgentServers,
+  type InstalledServer,
+} from "./reader.js";
+
+export type { AgentType, AgentConfig, McpServerConfig } from "./types.js";
+
+// AgentType plus any string; validated at runtime. The `string & {}` keeps
+// TypeScript autocomplete on AgentType literals without widening to `string`.
+export type AgentInput = AgentType | (string & {});
+
+function isKnownAgent(agentType: string): agentType is AgentType {
+  return Object.prototype.hasOwnProperty.call(agents, agentType);
+}
+
+function validate(agentType: AgentInput, local?: boolean): string | null {
+  if (!isKnownAgent(agentType)) {
+    return `Unknown agent type: ${String(agentType)}`;
+  }
+  if (local && !agents[agentType].localConfigPath) {
+    return `${agentType} does not support project-level config`;
+  }
+  return null;
+}
+
+export function upsertServer(
+  agentType: AgentInput,
+  serverName: string,
+  serverConfig: McpServerConfig,
+  options: InstallOptions = {},
+): InstallResult {
+  const error = validate(agentType, options.local);
+  if (error) return { success: false, path: "", error };
+  return installServerForAgent(
+    serverName,
+    serverConfig,
+    agentType as AgentType,
+    options,
+  );
+}
+
+export interface RemoveServerResult {
+  success: boolean;
+  path: string;
+  removed: boolean;
+  error?: string;
+}
+
+function hasServer(serversObj: unknown, serverName: string): boolean {
+  return (
+    !!serversObj &&
+    typeof serversObj === "object" &&
+    !Array.isArray(serversObj) &&
+    Object.prototype.hasOwnProperty.call(serversObj, serverName)
+  );
+}
+
+function doRemove(
+  agentType: AgentType,
+  serverName: string,
+  options: InstallOptions,
+): RemoveServerResult {
+  const agent = agents[agentType];
+  const configPath = getConfigPath(agent, options);
+  const configKey = getConfigKey(agent, options);
+
+  if (!existsSync(configPath)) {
+    return { success: true, path: configPath, removed: false };
+  }
+
+  const fullConfig = readConfig(configPath, agent.format);
+  if (!hasServer(getNestedValue(fullConfig, configKey), serverName)) {
+    return { success: true, path: configPath, removed: false };
+  }
+
+  removeServerFromConfig(configPath, agent.format, configKey, serverName);
+  return { success: true, path: configPath, removed: true };
+}
+
+export function removeServer(
+  agentType: AgentInput,
+  serverName: string,
+  options: InstallOptions = {},
+): RemoveServerResult {
+  const error = validate(agentType, options.local);
+  if (error) return { success: false, path: "", removed: false, error };
+  const known = agentType as AgentType;
+  try {
+    return doRemove(known, serverName, options);
+  } catch (e) {
+    return {
+      success: false,
+      path: getConfigPath(agents[known], options),
+      removed: false,
+      error: e instanceof Error ? e.message : "Unknown error",
+    };
+  }
+}

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -2,7 +2,7 @@ import type { AgentType, ConfigFile } from "./types.js";
 import {
   agents,
   detectProjectAgents,
-  detectAllGlobalAgents,
+  detectGlobalAgents,
 } from "./agents.js";
 import {
   getConfigPath,
@@ -142,7 +142,7 @@ export function readServersForAgent(
  * When `agents` is provided, those agents are included even if not detected
  * (with detected=false).
  */
-export async function gatherInstalledServers(options: {
+export async function listInstalledServers(options: {
   global?: boolean;
   agents?: AgentType[];
   cwd?: string;
@@ -154,7 +154,7 @@ export async function gatherInstalledServers(options: {
     // Explicit agent list: include even if not detected
     const detectedSet = new Set<AgentType>(
       options.global
-        ? await detectAllGlobalAgents()
+        ? await detectGlobalAgents()
         : detectProjectAgents(options.cwd),
     );
 
@@ -183,7 +183,7 @@ export async function gatherInstalledServers(options: {
   } else {
     // Auto-detect
     const detected = options.global
-      ? await detectAllGlobalAgents()
+      ? await detectGlobalAgents()
       : detectProjectAgents(options.cwd);
 
     for (const agentType of detected) {

--- a/tests/lib.test.ts
+++ b/tests/lib.test.ts
@@ -1,0 +1,291 @@
+#!/usr/bin/env tsx
+
+/**
+ * Unit tests for lib.ts (programmatic API)
+ *
+ * Run with: npx tsx tests/lib.test.ts
+ */
+
+import assert from "node:assert";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  detectProjectAgents,
+  detectGlobalAgents,
+  upsertServer,
+  removeServer,
+  listInstalledServers,
+  getAgentTypes,
+  type McpServerConfig,
+} from "../src/lib.js";
+
+const remote = (url: string): McpServerConfig => ({ type: "http", url });
+const pkg = (name: string): McpServerConfig => ({
+  command: "npx",
+  args: ["-y", name],
+});
+
+let passed = 0;
+let failed = 0;
+let tempDirs: string[] = [];
+
+function test(name: string, fn: () => void | Promise<void>): Promise<void> {
+  const run = async () => {
+    try {
+      await fn();
+      console.log(`✓ ${name}`);
+      passed++;
+    } catch (err) {
+      console.log(`✗ ${name}`);
+      console.error(`  ${(err as Error).message}`);
+      failed++;
+    }
+  };
+  return run();
+}
+
+function createTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "add-mcp-lib-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function cleanup() {
+  for (const dir of tempDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+  tempDirs = [];
+}
+
+function readJson(filePath: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(filePath, "utf-8"));
+}
+
+await test("detectProjectAgents finds cursor when .cursor exists", () => {
+  const dir = createTempDir();
+  mkdirSync(join(dir, ".cursor"), { recursive: true });
+  mkdirSync(join(dir, ".vscode"), { recursive: true });
+
+  const detected = detectProjectAgents(dir);
+  assert.ok(
+    detected.includes("cursor"),
+    `expected cursor in ${detected.join(", ")}`,
+  );
+  assert.ok(
+    detected.includes("vscode"),
+    `expected vscode in ${detected.join(", ")}`,
+  );
+});
+
+await test("detectProjectAgents returns empty for clean dir", () => {
+  const dir = createTempDir();
+  const detected = detectProjectAgents(dir);
+  assert.deepStrictEqual(detected, []);
+});
+
+await test("detectGlobalAgents returns an array of known agents", async () => {
+  const detected = await detectGlobalAgents();
+  assert.ok(Array.isArray(detected));
+  const known = new Set(getAgentTypes());
+  for (const agent of detected) {
+    assert.ok(known.has(agent), `${agent} should be a known AgentType`);
+  }
+});
+
+await test("upsertServer writes a remote server config", () => {
+  const dir = createTempDir();
+  const result = upsertServer(
+    "cursor",
+    "example",
+    remote("https://mcp.example.com/api"),
+    { local: true, cwd: dir },
+  );
+
+  assert.ok(result.success, result.error);
+  assert.ok(result.path.includes(dir));
+
+  const written = readJson(join(dir, ".cursor", "mcp.json"));
+  const servers = written.mcpServers as Record<string, unknown>;
+  assert.ok(servers.example, "server should be present");
+  const exampleConfig = servers.example as Record<string, unknown>;
+  assert.strictEqual(exampleConfig.url, "https://mcp.example.com/api");
+});
+
+await test("upsertServer updates an existing server in place", () => {
+  const dir = createTempDir();
+
+  const first = upsertServer(
+    "cursor",
+    "demo",
+    remote("https://old.example.com/api"),
+    { local: true, cwd: dir },
+  );
+  assert.ok(first.success);
+
+  const second = upsertServer(
+    "cursor",
+    "demo",
+    remote("https://new.example.com/api"),
+    { local: true, cwd: dir },
+  );
+  assert.ok(second.success);
+
+  const written = readJson(join(dir, ".cursor", "mcp.json"));
+  const demo = (written.mcpServers as Record<string, Record<string, unknown>>)
+    .demo;
+  assert.strictEqual(demo!.url, "https://new.example.com/api");
+});
+
+await test("listInstalledServers lists what upsertServer wrote", async () => {
+  const dir = createTempDir();
+  upsertServer("cursor", "listed", pkg("mcp-server-postgres"), {
+    local: true,
+    cwd: dir,
+  });
+
+  const list = await listInstalledServers({ cwd: dir });
+  const cursor = list.find((a) => a.agentType === "cursor");
+  assert.ok(cursor, "cursor should be detected");
+  const names = cursor!.servers.map((s) => s.serverName);
+  assert.ok(
+    names.includes("listed"),
+    `expected 'listed' in ${names.join(", ")}`,
+  );
+});
+
+await test("removeServer deletes an existing server", () => {
+  const dir = createTempDir();
+  upsertServer("cursor", "doomed", remote("https://x.example.com"), {
+    local: true,
+    cwd: dir,
+  });
+
+  const result = removeServer("cursor", "doomed", { local: true, cwd: dir });
+  assert.ok(result.success);
+  assert.strictEqual(result.removed, true);
+
+  const written = readJson(join(dir, ".cursor", "mcp.json"));
+  const servers = (written.mcpServers ?? {}) as Record<string, unknown>;
+  assert.ok(!servers.doomed, "doomed should be gone");
+});
+
+await test("removeServer returns removed=false when server is absent", () => {
+  const dir = createTempDir();
+  upsertServer("cursor", "kept", remote("https://k.example.com"), {
+    local: true,
+    cwd: dir,
+  });
+
+  const result = removeServer("cursor", "missing", {
+    local: true,
+    cwd: dir,
+  });
+  assert.ok(result.success);
+  assert.strictEqual(result.removed, false);
+
+  // The unrelated server should still be there.
+  const written = readJson(join(dir, ".cursor", "mcp.json"));
+  const servers = written.mcpServers as Record<string, unknown>;
+  assert.ok(servers.kept);
+});
+
+await test("removeServer returns removed=false when no config file exists", () => {
+  const dir = createTempDir();
+  const result = removeServer("cursor", "ghost", { local: true, cwd: dir });
+  assert.ok(result.success);
+  assert.strictEqual(result.removed, false);
+  assert.strictEqual(existsSync(join(dir, ".cursor", "mcp.json")), false);
+});
+
+await test("upsertServer returns error result for unknown agent type", () => {
+  const dir = createTempDir();
+  const result = upsertServer(
+    "not-a-real-agent",
+    "x",
+    remote("https://x.example.com"),
+    { local: true, cwd: dir },
+  );
+  assert.strictEqual(result.success, false);
+  assert.ok(result.error?.includes("Unknown agent type"));
+});
+
+await test("removeServer returns error result for unknown agent type", () => {
+  const result = removeServer("not-a-real-agent", "x");
+  assert.strictEqual(result.success, false);
+  assert.strictEqual(result.removed, false);
+  assert.ok(result.error?.includes("Unknown agent type"));
+});
+
+await test("upsertServer + removeServer reject local: true for global-only agents", () => {
+  const dir = createTempDir();
+  const upsert = upsertServer(
+    "claude-desktop",
+    "x",
+    remote("https://x.example.com"),
+    { local: true, cwd: dir },
+  );
+  assert.strictEqual(upsert.success, false);
+  assert.ok(upsert.error?.includes("does not support project-level"));
+
+  const remove = removeServer("claude-desktop", "x", {
+    local: true,
+    cwd: dir,
+  });
+  assert.strictEqual(remove.success, false);
+  assert.strictEqual(remove.removed, false);
+  assert.ok(remove.error?.includes("does not support project-level"));
+});
+
+await test("upsertServer + removeServer honor github-copilot-cli local `servers` key", () => {
+  const dir = createTempDir();
+
+  const installed = upsertServer(
+    "github-copilot-cli",
+    "ghc",
+    remote("https://mcp.example.com/api"),
+    { local: true, cwd: dir },
+  );
+  assert.ok(installed.success, installed.error);
+
+  const written = readJson(join(dir, ".vscode", "mcp.json"));
+  // Local copilot config uses `servers`, not `mcpServers`.
+  assert.ok(
+    written.servers && (written.servers as Record<string, unknown>).ghc,
+    "expected `servers.ghc` under local github-copilot-cli config",
+  );
+  assert.strictEqual(
+    written.mcpServers,
+    undefined,
+    "expected no `mcpServers` key under local copilot config",
+  );
+
+  const removed = removeServer("github-copilot-cli", "ghc", {
+    local: true,
+    cwd: dir,
+  });
+  assert.ok(removed.success);
+  assert.strictEqual(removed.removed, true);
+
+  const after = readJson(join(dir, ".vscode", "mcp.json"));
+  const servers = (after.servers ?? {}) as Record<string, unknown>;
+  assert.ok(!servers.ghc, "ghc should be removed from local servers key");
+});
+
+cleanup();
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Why

Make `add-mcp` usable as a library. Lets callers detect MCP clients, add/update, and remove server config without shelling out.

## What

- **`src/lib.ts`** — new library entry exporting `detectProjectAgents`, `detectGlobalAgents`, `listInstalledServers`, `upsertServer`, `removeServer`, `getAgentTypes`, `agents`, plus relevant types.
- **`package.json`** — adds `main` / `types` / `exports`; `tsup` emits both `dist/index.js` and `dist/lib.js`. Bumps to `1.10.0`.
- **`tests/lib.test.ts`** — 13 tests against temp dirs, no mocks.

## Test plan

- [x] `bun run typecheck`, `build`, `test`, `fallow` green locally
- [ ] PR CI green

## Notes

- Mixed sync/async surface (writes sync, detection async) — inherited; can unify later.
- Extended the pre-existing `&&` chains in test scripts rather than refactor them.