### PR TITLE
fix: use single quotes in --header/--env format error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.10.1] - 2026-05-22
+
+- use single quotes in `--header` / `--env` "Use 'Key: Value' format." error messages so the example matches the recommended shell-quoting style (was double quotes, which contradicted the shell-expansion hint that recommends single quotes)
+
 ## [1.10.0] - 2026-05-21
 
 - expose programmatic API

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1294,7 +1294,7 @@ async function main(target: string | undefined, options: Options) {
       ? " (looks like your shell expanded a ${VAR} to an empty string; use single quotes: --header 'Key: ${VAR}' to pass the template literally)"
       : "";
     p.log.error(
-      `Invalid --header value(s): ${headerResult.invalid.join(", ")}. Use "Key: Value" format.${hint}`,
+      `Invalid --header value(s): ${headerResult.invalid.join(", ")}. Use 'Key: Value' format.${hint}`,
     );
     process.exit(1);
   }
@@ -1312,7 +1312,7 @@ async function main(target: string | undefined, options: Options) {
       ? " (looks like your shell expanded a ${VAR} to an empty string; use single quotes: --env 'KEY=${VAR}' to pass the template literally)"
       : "";
     p.log.error(
-      `Invalid --env value(s): ${envResult.invalid.join(", ")}. Use "KEY=VALUE" format.${hint}`,
+      `Invalid --env value(s): ${envResult.invalid.join(", ")}. Use 'KEY=VALUE' format.${hint}`,
     );
     process.exit(1);
   }

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -581,7 +581,7 @@ test("E2E CLI: invalid --env format exits with error", () => {
 
   const output = `${result.stdout}\n${result.stderr}`;
   assert.match(output, /Invalid --env value\(s\)/);
-  assert.match(output, /Use "KEY=VALUE" format\./);
+  assert.match(output, /Use 'KEY=VALUE' format\./);
 });
 
 test("E2E CLI: --header with empty value hints at shell expansion", () => {


### PR DESCRIPTION
## Why

After [#40](https://github.com/neon-solutions/add-mcp/pull/40), the full error message for an empty \`--header\` value reads:

\`\`\`
Invalid --header value(s): Authorization: . Use \"Key: Value\" format. (looks like your shell expanded a \${VAR} to an empty string; use single quotes: --header 'Key: \${VAR}' to pass the template literally)
\`\`\`

The first half says \`\"Key: Value\"\` with double quotes; the second half tells the user to use single quotes to avoid shell expansion. That's contradictory. The double-quoted example reinforces the exact mistake the hint is trying to fix.

## What

Change the format-example quotes to single quotes in both \`--header\` and \`--env\` error messages so the whole message recommends the same shell-quoting style:

\`\`\`
Invalid --header value(s): Authorization: . Use 'Key: Value' format. (... use single quotes: --header 'Key: \${VAR}' ...)
Invalid --env value(s): API_KEY=. Use 'KEY=VALUE' format. (... use single quotes: --env 'KEY=\${VAR}' ...)
\`\`\`

## Test plan

- [x] Existing \`E2E CLI: invalid --env format exits with error\` test updated to match the new single-quote regex; \`bun run test\` green (32/32).
- [x] \`bun run typecheck\` green.
- [ ] PR CI green on Ubuntu.

## Release

Bumps to \`1.10.1\` with a CHANGELOG entry.

Made with [Cursor](https://cursor.com)