### PR TITLE
docs: add programmatic API example to README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ Example installing the Context7 remote MCP server:
 npx add-mcp https://mcp.context7.com/mcp
 ```
 
+Example installing the Context7 remote MCP server via the programmatic API — great for integrating add-mcp in your own CLI tool:
+
+```ts
+import { upsertServer } from "add-mcp";
+
+const result = upsertServer(
+  "cursor",
+  "context7",
+  { type: "http", url: "https://mcp.context7.com/mcp" },
+  { local: true, cwd: process.cwd() },
+);
+console.log(result);
+```
+
 You can add env variables and arguments (stdio) and headers (remote) to the server config using the `--env`, `--args` and `--header` options. With `${VAR}` placeholders, interactive installs prompt for each variable (omit skipped optional keys so empty strings are not written to config).
 
 ## Find an MCP Servers

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const result = upsertServer(
   "cursor",
   "context7",
   { type: "http", url: "https://mcp.context7.com/mcp" },
-  { local: true, cwd: process.cwd() },
+  { local: true },
 );
 console.log(result);
 ```


### PR DESCRIPTION
## Summary
- Adds a Context7 programmatic API example directly below the existing CLI example at the top of the README
- Shows how to use `upsertServer` from `add-mcp` for integrating MCP installs into custom tooling

## Test plan
- [x] README-only change; no code or tests affected


Made with [Cursor](https://cursor.com)