### PR TITLE
feat: add -h shorthand for --header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.10.4] - 2026-05-23
+
+- add `-h` shorthand for `--header` (use `--help` for help)
+
 ## [1.10.3] - 2026-05-23
 
 - add `windsurf` support with global installs written to `~/.codeium/windsurf/mcp_config.json` (`mcpServers`); aliases: `codeium`, `cascade` ([#31](https://github.com/neon-solutions/add-mcp/pull/31))

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ npx add-mcp https://mcp.example.com/mcp -a cursor -y --gitignore
 | `-a, --agent <agent>`    | Target specific agents (e.g., `cursor`, `claude-code`). Can be repeated. |
 | `-t, --transport <type>` | Transport type for remote servers: `http` (default), `sse`               |
 | `--type <type>`          | Alias for `--transport`                                                  |
-| `--header <header>`      | HTTP header for remote servers (repeatable, `Key: Value`)                |
+| `-h, --header <header>`  | HTTP header for remote servers (repeatable, `Key: Value`)                |
 | `--env <env>`            | Env var for local stdio servers (repeatable, `KEY=VALUE`)                |
 | `-n, --name <name>`      | Server name (auto-inferred if not provided)                              |
 | `-y, --yes`              | Skip all confirmation prompts                                            |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,7 +242,7 @@ function extractSubcommandOptionsFromArgv(): Partial<Options> {
       result.gitignore = true;
       continue;
     }
-    if (arg === "--header" && argv[i + 1]) {
+    if ((arg === "-h" || arg === "--header") && argv[i + 1]) {
       const headers: string[] = result.header ? [...result.header] : [];
       headers.push(argv[i + 1]!);
       result.header = headers;
@@ -414,6 +414,7 @@ program
     "Install MCP servers for coding agents (Claude Code, Cursor, VS Code, OpenCode, Codex, and more — run list-agents for the full list)",
   )
   .version(version)
+  .helpOption("--help", "display help for command")
   .argument("[target]", "MCP server URL (remote) or package name (local stdio)")
   .option(
     "-g, --global",
@@ -430,7 +431,7 @@ program
   )
   .option("--type <type>", "Alias for --transport")
   .option(
-    "--header <header>",
+    "-h, --header <header>",
     "HTTP header for remote servers (repeatable, 'Key: Value'). Placeholders ${VAR} prompt interactively when not using --yes. Use single quotes so your shell does not expand the ${VAR}.",
     collect,
     [],

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -419,6 +419,44 @@ test("E2E CLI: Goose HTTP install with headers", () => {
   });
 });
 
+test("E2E CLI: Goose HTTP install with -h header shorthand", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "goose",
+      "-y",
+      "--name",
+      "example",
+      "-h",
+      "Authorization: Bearer token",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const gooseConfigPath = join(homeDir, ".config", "goose", "config.yaml");
+  const saved = yaml.load(readFileSync(gooseConfigPath, "utf-8")) as Record<
+    string,
+    unknown
+  >;
+  const extensions = saved.extensions as Record<string, unknown>;
+  const server = extensions.example as Record<string, unknown>;
+
+  assert.deepStrictEqual(server.headers, {
+    Authorization: "Bearer token",
+  });
+});
+
 test("E2E CLI: remote server to claude-desktop errors with custom message", () => {
   const projectDir = createTempDir();
   const homeDir = createTempDir();


### PR DESCRIPTION
## Summary

- Add `-h` as a shorthand for `--header` when installing remote MCP servers
- Move help to `--help` only (Commander previously used `-h` for help, which conflicted)
- Update argv re-parsing so `-h` works on subcommands the same way as other shared flags

## Test plan

- [x] `bun run test` (includes new e2e test for `-h` header shorthand)
- [x] `add-mcp --help` shows `-h, --header` and `--help` (no `-h` for help)


Made with [Cursor](https://cursor.com)