### PR TITLE
Add OptionsAhoy to curated registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1050,5 +1050,25 @@
       ],
       "title": "Vercel"
     }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "io.github.AlvisoOculus/optionsahoy_web",
+      "title": "OptionsAhoy",
+      "description": "Multi-year equity-compensation optimizer: ISO/AMT scheduling, NSO sell-vs-hold, RSU vest decisions, single-stock concentration, protective puts, QSBS qualification. Full federal + 50-state + DC tax code.",
+      "version": "1.0.1",
+      "repository": {
+        "url": "https://github.com/AlvisoOculus/optionsahoy_web",
+        "source": "github"
+      },
+      "websiteUrl": "https://optionsahoy.com/for-agents",
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://optionsahoy.com/mcp"
+        }
+      ]
+    }
   }
 ]

--- a/registry.json
+++ b/registry.json
@@ -1054,12 +1054,12 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "io.github.AlvisoOculus/optionsahoy_web",
+      "name": "io.github.AlvisoOculus/optionsahoy-mcp",
       "title": "OptionsAhoy",
       "description": "Multi-year equity-compensation optimizer: ISO/AMT scheduling, NSO sell-vs-hold, RSU vest decisions, single-stock concentration, protective puts, QSBS qualification. Full federal + 50-state + DC tax code.",
       "version": "1.0.1",
       "repository": {
-        "url": "https://github.com/AlvisoOculus/optionsahoy_web",
+        "url": "https://github.com/AlvisoOculus/optionsahoy-mcp",
         "source": "github"
       },
       "websiteUrl": "https://optionsahoy.com/for-agents",


### PR DESCRIPTION
Adds OptionsAhoy, a remote HTTP MCP server for multi-year equity-compensation optimization, to the curated `registry.json`.

**Server:** `https://optionsahoy.com/mcp` (streamable-http, JSON-RPC 2.0, protocol 2024-11-05)
**Auth:** none
**Docs:** https://optionsahoy.com/for-agents
**Already published to:** Official MCP Registry as `io.github.AlvisoOculus/optionsahoy_web` v1.0.1, status active ([API](https://registry.modelcontextprotocol.io/v0/servers?search=optionsahoy))

**What it is**

Multi-year equity-compensation optimization engine. Six tools that return the globally-optimal schedule across the candidate space, against the full federal tax code (ordinary brackets, LTCG, AMT with credit recovery, FICA, NIIT) plus all 50 states and DC (state ordinary brackets, LTCG treatment, state AMT for CA/NY/MN).

Tools:
- `amt_iso_optimize` — multi-year ISO exercise schedule minimizing AMT
- `nso_calculate` — NSO exercise tax + sell-vs-hold
- `rsu_sell_vs_hold` — RSU sell-at-vest vs hold-for-LTCG
- `concentration_analyze` — single-stock concentration risk
- `protective_put_price` — protective put / zero-cost collar pricing
- `qsbs_check` — Section 1202 QSBS qualification

Same engine as the in-browser tools at https://optionsahoy.com/tools — response is byte-identical.

**Why include in the curated list**

A benchmark of five frontier LLMs on the same multi-year ISO problem found all 15 trials overshot the achievable after-tax outcome by 2x to 20x relative to the optimizer — making this exactly the class of tool an AI agent should hand off to rather than computing in-context: https://hackernoon.com/but-can-it-do-taxes-though-why-you-shouldnt-trust-chatbots-with-tax-optimization-math

Built by AlphaLatitude Inc. (pre-revenue beta-stage product).

Entry inserted alphabetically by `server.name` to match the file's existing convention.