### PR TITLE
Add Pyrimid MCP server to registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -710,6 +710,26 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "ai.pyrimid/mcp",
+      "title": "Pyrimid",
+      "description": "Official Pyrimid MCP server for discovering paid AI and API products with x402 and Base USDC.",
+      "repository": {
+        "url": "https://github.com/pyrimid-ai/pyrimid",
+        "source": "github"
+      },
+      "version": "1.0.0",
+      "websiteUrl": "https://pyrimid.ai",
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://pyrimid.ai/api/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "io.github.railwayapp/mcp-server",
       "description": "Official Railway MCP server",
       "repository": {


### PR DESCRIPTION
## Summary
- add Pyrimid's official remote MCP server to the curated registry
- include the public GitHub repo, website, and streamable HTTP endpoint

## Verification
- Verified 35 registry entries
- 
- CLI Building entry: src/index.ts, src/lib.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Target: esnext
CLI Cleaning output folder
ESM Build start
ESM dist/index.js          69.62 KB
ESM dist/chunk-ONLHW5AV.js 39.92 KB
ESM dist/lib.js            2.35 KB
ESM ⚡️ Build success in 51ms
DTS Build start
DTS ⚡️ Build success in 1135ms
DTS dist/index.d.ts 20.00 B
DTS dist/lib.d.ts   3.80 KB
- ✓ Remote URL - HTTPS with mcp subdomain
✓ Remote URL - HTTP localhost
✓ Remote URL - with api subdomain
✓ Remote URL - mcp.neon.tech extracts neon
✓ Remote URL - workos.com extracts workos
✓ Remote URL - mcp.sentry.io extracts sentry
✓ Package name - simple
✓ Package name - scoped
✓ Package name - with version
✓ Package name - scoped with version
✓ Command - npx with package
✓ Command - node with script
✓ Command - python
✓ Command - complex with args
✓ Command - absolute path without spaces
✓ Command - absolute path with spaces preserved as single value
✓ Command - home-relative path with spaces
✓ Command - dot-relative path
✓ Command - parent-relative path with spaces
✓ Command - Windows path with spaces
✓ Command - Windows path with forward slashes
✓ Command - absolute path with trailing slash binary
✓ isRemoteSource - remote URL returns true
✓ isRemoteSource - package returns false
✓ isLocalSource - package returns true
✓ isLocalSource - command returns true
✓ isLocalSource - remote URL returns false
✓ Whitespace trimming
✓ Name inference - server- prefix removed
✓ Name inference - -mcp suffix removed

30 passed, 0 failed
✓ getAgentTypes returns all 15 agents
✓ All agents have required properties
✓ supportsProjectConfig - returns true for project-capable agents
✓ supportsProjectConfig - returns false for global-only agents
✓ getProjectCapableAgents returns 9 agents
✓ getGlobalOnlyAgents returns 6 agents
✓ Project + global-only agents equals all agents
✓ detectProjectAgents - empty directory returns empty array
✓ detectProjectAgents - detects .cursor directory
✓ detectProjectAgents - detects .vscode directory
✓ detectProjectAgents - detects .mcp.json file (claude-code)
✓ detectProjectAgents - detects .claude directory (claude-code)
✓ detectProjectAgents - detects opencode.json file
✓ detectProjectAgents - detects .opencode directory
✓ detectProjectAgents - detects .gemini directory
✓ detectProjectAgents - detects .codex directory
✓ detectProjectAgents - detects .zed directory
✓ detectProjectAgents - detects config/mcporter.json
✓ detectProjectAgents - detects multiple agents
✓ detectProjectAgents - does not detect global-only agents
✓ isTransportSupported - all agents support stdio
✓ isTransportSupported - most agents support http
✓ isTransportSupported - most agents support sse
✓ isTransportSupported - antigravity supports stdio, http, and sse
✓ antigravity has no unsupportedTransportMessage
✓ isTransportSupported - claude-desktop only supports stdio
✓ claude-desktop has unsupportedTransportMessage
✓ Project-capable agents have localConfigPath
✓ Global-only agents do not have localConfigPath
✓ Project-capable agents have non-empty projectDetectPaths
✓ Global-only agents have empty projectDetectPaths
✓ buildAgentSelectionChoices orders detected, last selected, then remaining

32 passed, 0 failed
✓ readConfig returns empty config for missing file
✓ saveSelectedAgents persists last selection
✓ readConfig resets when version is missing
✓ saveFindRegistries persists registry selections
✓ config is written to ~/.config/add-mcp/config.json
✓ migrates from legacy ~/.agents/.mcp-lock.json
✓ prefers new config over legacy when both exist
✓ respects XDG_CONFIG_HOME

8 passed, 0 failed
✓ buildServerConfig - remote URL defaults to http
✓ buildServerConfig - remote URL with headers
✓ buildServerConfig - remote URL with path
✓ buildServerConfig - remote URL with transport sse
✓ buildServerConfig - remote URL with transport http
✓ buildServerConfig - simple package
✓ buildServerConfig - scoped package
✓ buildServerConfig - package with version
✓ buildServerConfig - package includes env when provided
✓ buildServerConfig - package appends args when provided
✓ buildServerConfig - package includes env and args together
✓ buildServerConfig - npx command
✓ buildServerConfig - node command
✓ buildServerConfig - python command
✓ buildServerConfig - command with multiple args
✓ buildServerConfig - command includes env when provided
✓ buildServerConfig - command appends args when provided
✓ buildServerConfig - absolute path with spaces stays a single command
✓ buildServerConfig - absolute path with spaces still accepts --args
✓ buildServerConfig - absolute path without spaces
✓ buildServerConfig - home-relative path with spaces
✓ buildServerConfig - dot-relative path with spaces
✓ buildServerConfig - Windows path with spaces
✓ buildServerConfig - remote source ignores env
✓ installServer - routes agents based on routing map
✓ installServer - mixed routing (local and global simulation)
✓ installServer - empty routing map defaults to global
✓ installServer - routing with multiple agents to different scopes
✓ installServer - github-copilot-cli local uses VS Code servers key
✓ installServer - github-copilot-cli global uses mcpServers key and CLI schema
✓ installServer - cline-cli global uses mcpServers key and Cline schema
✓ installServer - cline extension global uses VS Code global storage path
✓ installServer - mcporter local writes config/mcporter.json
✓ installServer - mcporter global prefers existing mcporter.jsonc
✓ installServer - mcporter global prefers mcporter.json over mcporter.jsonc
✓ updateGitignoreWithPaths - creates .gitignore when missing
✓ updateGitignoreWithPaths - appends only new local paths

37 passed, 0 failed
✓ searchRegistry maps API response entries
✓ searchRegistry returns failure info on non-ok response
✓ searchRegistry merges registries and skips failed sources
✓ rankRegistryEntries prioritizes official GitHub over smithery noise
✓ filterSmitheryWhenAlternativesExist removes smithery when non-smithery exists
✓ filterSmitheryWhenAlternativesExist keeps smithery when only smithery exists
✓ rankRegistryEntries prioritizes official Supabase over smithery entries
✓ formatFindResultRow shows title, name, and transport labels
✓ formatFindResultRow falls back to name when no title
✓ buildInstallPlanForEntry defaults to remote in -y for hybrid entries
✓ resolveServerName uses lowercased title when present
✓ resolveServerName removes com and mcp from fallback name
✓ resolveTemplateUrl replaces provided variables only
✓ collectPromptValues uses placeholder for empty required, omits empty optional
✓ collectPromptValues keeps user-provided values for required fields
✓ matrix: variable optional + header optional
✓ matrix: variable required + header optional
✓ matrix: variable optional + header required
✓ matrix: variable required + header required
✓ buildInstallPlanForEntry injects placeholders in -y mode
✓ searchRegistry fetches entries for blank query (browse mode)
✓ searchRegistry fetches entries for empty string query (browse mode)
✓ resolveOfficialRegistryServersUrl returns the default registry URL
✓ buildInstallPlanForEntry returns package target for package-only entry
✓ buildInstallPlanForEntry includes only required package env/header/args placeholders in -y mode
✓ buildInstallPlanForEntry omits env/headers/args when all package inputs are optional in -y mode
✓ buildInstallPlanForEntry merges named packageArguments in -y mode
✓ buildInstallPlanForEntry filters blank-name env variables in -y mode
✓ buildInstallPlanForEntry uses positional packageArguments in -y mode
✓ buildInstallPlanForEntry returns null when entry has no remotes or packages
✓ formatFindResultRow shows stdio for package-only entries
✓ formatFindResultRow shows unknown transport when neither remote nor package
✓ resolveServerName returns 'server' as ultimate fallback
✓ formatRegistryFailure shows label for known registries
✓ formatRegistryFailure shows only URL for custom registries
✓ getDefaultFindRegistries returns two hardcoded registries
✓ buildInstallPlanForEntry picks SSE remote when preferred transport is sse
✓ buildInstallPlanForEntry defaults to streamable-http when no transport preference
✓ buildInstallPlanForEntry falls back to available remote when preferred transport missing
✓ searchRegistry filters out non-installable entries (no npm package and no remotes)

40 passed, 0 failed
✓ normalizeNamedFlag keeps leading dashes
✓ normalizeNamedFlag prefixes bare names
✓ isNamedArg respects explicit positional type
✓ isNamedArg respects explicit named type
✓ isNamedArg infers named when type empty and name set
✓ isNamedArg infers positional when type empty and only valueHint
✓ definitionsFromPackage reads packageArguments only
✓ buildPackageArgumentsArgvNonInteractive: named constant emits flag and value
✓ buildPackageArgumentsArgvNonInteractive: named required empty uses placeholder
✓ buildPackageArgumentsArgvNonInteractive: optional named omitted when unset
✓ buildPackageArgumentsArgvNonInteractive: positional literal
✓ buildPackageArgumentsArgvNonInteractive: templates substituted in -y mode

12 passed, 0 failed
✓ findTemplateVars returns empty array for plain string
✓ findTemplateVars returns empty array for empty string
✓ findTemplateVars extracts single variable
✓ findTemplateVars extracts variable embedded in text
✓ findTemplateVars extracts multiple variables
✓ findTemplateVars ignores incomplete syntax
✓ findTemplateVars is reentrant across calls
✓ substituteTemplatePlaceholders replaces each template
✓ resolveTemplates returns value unchanged when no templates
✓ resolveTemplates substitutes single template
✓ resolveTemplates substitutes template embedded in text
✓ resolveTemplates substitutes multiple templates
✓ resolveTemplates returns cancelled when prompt is cancelled
✓ resolveTemplates substitutes empty string for empty input
✓ resolveTemplates stops prompting after cancel on first of multiple
✓ hasTemplateVars returns false for plain record values
✓ hasTemplateVars returns true when record has template
✓ hasTemplateVars returns false for plain array
✓ hasTemplateVars returns true when array has template
✓ hasTemplateVars returns false for empty inputs
✓ resolveRecordTemplates resolves templates in record values
✓ resolveRecordTemplates returns cancelled on abort
✓ resolveRecordTemplates passes through record with no templates
✓ resolveArrayTemplates resolves templates in array values
✓ resolveArrayTemplates returns cancelled on abort
✓ resolveArrayTemplates passes through array with no templates

26 passed, 0 failed
✓ extractServerIdentity: standard url field
✓ extractServerIdentity: Goose uri field
✓ extractServerIdentity: Antigravity serverUrl field
✓ extractServerIdentity: npx package detection
✓ extractServerIdentity: npx without -y flag
✓ extractServerIdentity: bunx package detection
✓ extractServerIdentity: full command identity
✓ extractServerIdentity: command only, no args
✓ extractServerIdentity: empty config returns empty string
✓ extractServerIdentity: prefers url over command
✓ readServersForAgent: reads JSON config for cursor
✓ readServersForAgent: returns empty servers for missing config
✓ readServersForAgent: reads from claude-code .mcp.json
✓ readServersForAgent: reads VS Code config with 'servers' key
✓ findMatchingServers: matches by exact server name
✓ findMatchingServers: matches by case-insensitive substring on name
✓ findMatchingServers: matches by exact URL identity
✓ findMatchingServers: matches by package name identity
✓ findMatchingServers: returns empty array for no matches
✓ findMatchingServers: finds matches across multiple agents

20 passed, 0 failed
✓ JSON: removes server key, preserves other keys
✓ JSON: removing last server leaves empty servers object
✓ JSON: preserves comments in JSONC files
✓ JSON: no-op on nonexistent file
✓ JSON: no-op when server name not found
✓ YAML: removes server key from nested config
✓ YAML: no-op on nonexistent file
✓ TOML: removes server key from nested config
✓ TOML: no-op on nonexistent file

9 passed, 0 failed
✓ detectProjectAgents finds cursor when .cursor exists
✓ detectProjectAgents returns empty for clean dir
✓ detectGlobalAgents returns an array of known agents
✓ upsertServer writes a remote server config
✓ upsertServer updates an existing server in place
✓ listInstalledServers lists what upsertServer wrote
✓ removeServer deletes an existing server
✓ removeServer returns removed=false when server is absent
✓ removeServer returns removed=false when no config file exists
✓ upsertServer returns error result for unknown agent type
✓ removeServer returns error result for unknown agent type
✓ upsertServer + removeServer reject local: true for global-only agents
✓ upsertServer + removeServer honor github-copilot-cli local `servers` key

13 passed, 0 failed
✓ E2E: Install remote MCP to Cursor (local)
✓ E2E: Install remote MCP to Cursor (local, sse)
✓ E2E: Install package MCP to Cursor (local)
✓ E2E: Install command MCP to Claude Code (local)
✓ E2E: Install to VS Code (local)
✓ E2E: Install to GitHub Copilot CLI (local) writes VS Code schema
✓ E2E: Install to OpenCode (local) - transformed format
✓ E2E: Install local server to OpenCode - transformed format
✓ E2E: Install local server to OpenCode maps env to environment
✓ E2E: Install to Gemini CLI (local)
✓ E2E: Merge with existing config - preserves other servers
✓ E2E: Overwrite existing server with same name
✓ E2E: Install to Goose (YAML format, transformed) - local server
✓ E2E: Install to Goose (YAML format, transformed) maps env to envs
✓ E2E: Install to Goose (YAML format, transformed) - remote server (http)
✓ E2E: Install to Goose (YAML format, transformed) - remote server (http) with headers
✓ E2E: Install to Goose (YAML format, transformed) - remote server (sse)
✓ E2E: Install to Goose (YAML format, transformed) - remote server (sse) with headers
✓ E2E: Write YAML config file (Goose format)
✓ E2E: Zed config transformation - remote server
✓ E2E: Zed config transformation - local server
✓ E2E: Zed config transformation - local server includes env
✓ E2E: Cline VSCode extension config transformation - remote http server
✓ E2E: Cline VSCode extension config transformation - local stdio server
✓ E2E: Cline VSCode extension config transformation - local stdio includes env
✓ E2E: Cline CLI config transformation - local stdio server
✓ E2E: Codex config transformation
✓ E2E: Codex config transformation with headers
✓ E2E: Codex config transformation - local server
✓ E2E: Codex config transformation - local server includes env
✓ E2E: Write TOML config file (Codex format)
✓ E2E: Install to multiple agents

32 passed, 0 failed
✓ E2E CLI: absolute path with spaces is preserved as single command
✓ E2E CLI: absolute path with spaces accepts repeated --args
✓ E2E CLI: --gitignore adds local config path
✓ E2E CLI: --gitignore with --global warns and does not write project .gitignore
✓ E2E CLI: find -y without registry config asks to configure registries
✓ E2E CLI: find -y picks best match and installs remote with placeholders
✓ E2E CLI: search alias defaults to HTTP endpoint when both are available
✓ E2E CLI: mcporter default install writes project config
✓ E2E CLI: mcporter global install writes home config
✓ E2E CLI: Goose HTTP install with headers
✓ E2E CLI: Goose HTTP install with -h header shorthand
✓ E2E CLI: remote server to claude-desktop errors with custom message
✓ E2E CLI: --all skips claude-desktop for remote server with custom message
✓ E2E CLI: stdio server to claude-desktop succeeds
✓ E2E CLI: remote server to antigravity succeeds with serverUrl config
✓ E2E CLI: --all includes antigravity for remote server
✓ E2E CLI: stdio server to antigravity succeeds
✓ E2E CLI: remote server to windsurf succeeds with serverUrl config
✓ E2E CLI: --all includes windsurf for remote server
✓ E2E CLI: stdio server to windsurf succeeds
✓ E2E CLI: windsurf aliases (codeium, cascade) install to windsurf config
✓ E2E CLI: local stdio install supports repeated --env
✓ E2E CLI: invalid --env format exits with error
✓ E2E CLI: --header with empty value hints at shell expansion
✓ E2E CLI: --env with empty value hints at shell expansion
✓ E2E CLI: --env with no equals does not show shell-expansion hint
✓ E2E CLI: --header with no colon does not show shell-expansion hint
✓ E2E CLI: remote install with --env warns and succeeds
✓ list: shows servers for detected agents in project
✓ list: shows 'no servers configured' when agent detected but empty
✓ list: shows 'not detected' when -a targets absent agent
✓ list: shows help when no agents detected
✓ remove: removes server by name with -y
✓ remove: matches by URL identity with -y
✓ remove: prints message when no matches found
✓ sync: renames servers to canonical name across agents with -y
✓ sync: reconstructs required fields when syncing Cursor -> Claude Code
✓ sync: skips servers with header conflicts
✓ sync: prints already in sync when nothing to change

39 passed, 0 failed

Note: Dead Code Summary

       1  Unused files
       4  Unused exports
       3  Duplicate exports

       8  Total
Duplication Summary

      18  Clone families
      55  Clone groups
   1,472  Duplicated lines
   12.7%  Duplication rate
Health Summary

     686  Functions analyzed
      75  Above threshold
   90.5   Average maintainability (good) reports existing dead-code/duplication findings in this shallow clone; no registry-specific issue was reported.