### PR TITLE
Add Xquik MCP registry entry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1050,5 +1050,29 @@
       ],
       "title": "Vercel"
     }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.xquik/mcp",
+      "title": "Xquik",
+      "description": "Xquik MCP server for X data workflows, account monitoring, extraction jobs, and webhooks.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.xquik.com/mcp/overview",
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://xquik.com/mcp",
+          "headers": [
+            {
+              "name": "X-API-Key",
+              "description": "Xquik API key.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- Add Xquik to the curated MCP registry as a streamable HTTP remote.
- Require the X-API-Key header as a secret input.

## Validation
- bun run registry:verify
- bun run typecheck
- bun run build
- bun run test:unit
- bun run test:e2e
- Checked Xquik docs 200 and MCP endpoint returns 401 without an API key.

Disclosure: I am affiliated with Xquik.