### PR TITLE
feat: capability-gated --timeout / --scopes for remote servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.11.0] - 2026-06-20
+
+- add `--timeout <ms>` and `--scopes <scopes>` (alias `--oauth-scopes`) flags for remote servers. Fields are capability-gated per client and mapped to each client's native shape: `--timeout` → Claude Code / Gemini CLI `timeout`; `--scopes` → Cursor `auth.scopes` and Gemini CLI `oauth.scopes`. Agents that don't support a field have it dropped with a warning, so other agents still receive it ([#51](https://github.com/neon-solutions/add-mcp/issues/51))
+- make `transformConfig` required for every agent and gate writes through a single canonical schema, so only known fields are ever written to a client config (previously Claude Code, Claude Desktop, Gemini CLI, VS Code, and mcporter wrote the raw config and could leak unknown fields)
+
 ## [1.10.4] - 2026-05-23
 
 - add `-h` shorthand for `--header` (use `--help` for help)

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ npx add-mcp https://mcp.example.com/sse --transport sse
 # Remote MCP server with auth header
 npx add-mcp https://mcp.example.com/mcp --header "Authorization: Bearer $TOKEN"
 
+# Remote server with a request timeout and OAuth scopes
+# (each agent only keeps the fields it supports; others are dropped with a warning)
+npx add-mcp https://mcp.example.com/mcp --timeout 30000 --scopes "read,write"
+
 # npm package (runs via npx)
 npx add-mcp @modelcontextprotocol/server-postgres
 
@@ -168,10 +172,29 @@ npx add-mcp https://mcp.example.com/mcp -a cursor -y --gitignore
 | `--type <type>`          | Alias for `--transport`                                                  |
 | `-h, --header <header>`  | HTTP header for remote servers (repeatable, `Key: Value`)                |
 | `--env <env>`            | Env var for local stdio servers (repeatable, `KEY=VALUE`)                |
+| `--timeout <ms>`         | Request timeout (ms) for remote servers (capability-gated, see below)    |
+| `--scopes <scopes>`      | OAuth scopes for remote servers, comma-separated (capability-gated)      |
+| `--oauth-scopes <scopes>`| Alias for `--scopes`                                                     |
 | `-n, --name <name>`      | Server name (auto-inferred if not provided)                              |
 | `-y, --yes`              | Skip all confirmation prompts                                            |
 | `--all`                  | Install to all agents                                                    |
 | `--gitignore`            | Add generated config files to `.gitignore`                               |
+
+#### Capability-gated fields (`--timeout`, `--scopes`)
+
+Not every MCP client understands every field. `add-mcp` keeps one canonical
+server config and each agent declares which optional fields it supports, mapping
+them into that client's native shape:
+
+| Field      | Flag             | Supported by                | Mapped to                          |
+| ---------- | ---------------- | --------------------------- | ---------------------------------- |
+| Timeout    | `--timeout`      | Claude Code, Gemini CLI     | `timeout` (milliseconds)           |
+| OAuth scopes | `--scopes`     | Cursor, Gemini CLI          | Cursor `auth.scopes`, Gemini `oauth.scopes` |
+
+When you target an agent that does not support a field, `add-mcp` drops it from
+that agent's config and prints a warning (e.g. _"request timeout is not
+supported by VS Code; dropped from that config."_). Other agents still receive
+it. Both flags apply to remote servers only.
 
 ### Transport Types
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -72,6 +72,67 @@ const windsurfConfigPath = join(
   "mcp_config.json",
 );
 
+/**
+ * Build the spec-aligned remote shape shared by clients that consume MCP
+ * servers more or less verbatim (`{ type?, url, headers?, timeout? }`). Only
+ * keys with meaningful values are emitted so nothing unknown leaks through.
+ */
+function buildStandardRemote(config: McpServerConfig): Record<string, unknown> {
+  const remote: Record<string, unknown> = {};
+  if (config.type) remote.type = config.type;
+  if (config.url) remote.url = config.url;
+  if (config.headers && Object.keys(config.headers).length > 0) {
+    remote.headers = config.headers;
+  }
+  if (typeof config.timeout === "number") {
+    remote.timeout = config.timeout;
+  }
+  return remote;
+}
+
+/** Build the standard local (stdio) shape: `{ command, args, env? }`. */
+function buildStandardLocal(config: McpServerConfig): Record<string, unknown> {
+  const local: Record<string, unknown> = {
+    command: config.command,
+    args: config.args || [],
+  };
+  if (config.env && Object.keys(config.env).length > 0) {
+    local.env = config.env;
+  }
+  return local;
+}
+
+/**
+ * Default transform for spec-aligned clients (Claude Code, Claude Desktop, VS
+ * Code). Builds a fresh object with only known keys, so unsupported optional
+ * fields can never leak even though these clients otherwise mirror the schema.
+ */
+function transformStandardConfig(
+  _serverName: string,
+  config: McpServerConfig,
+): unknown {
+  return config.url ? buildStandardRemote(config) : buildStandardLocal(config);
+}
+
+/**
+ * Gemini CLI mirrors the standard shape but nests OAuth scopes under an
+ * `oauth.scopes` array (its documented location for remote auth scopes).
+ */
+function transformGeminiConfig(
+  _serverName: string,
+  config: McpServerConfig,
+): unknown {
+  if (!config.url) {
+    return buildStandardLocal(config);
+  }
+
+  const remote = buildStandardRemote(config);
+  if (config.oauthScopes && config.oauthScopes.length > 0) {
+    remote.oauth = { scopes: config.oauthScopes };
+  }
+  return remote;
+}
+
 function transformGooseConfig(
   serverName: string,
   config: McpServerConfig,
@@ -180,10 +241,14 @@ function transformCursorConfig(
       remoteConfig.headers = config.headers;
     }
 
+    if (config.oauthScopes && config.oauthScopes.length > 0) {
+      remoteConfig.auth = { scopes: config.oauthScopes };
+    }
+
     return remoteConfig;
   }
 
-  return config;
+  return buildStandardLocal(config);
 }
 
 function transformClineConfig(
@@ -312,6 +377,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "mcpServers",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
     detectGlobalInstall: async () => {
       return existsSync(join(home, ".gemini"));
     },
@@ -326,6 +392,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "mcpServers",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
     detectGlobalInstall: async () => {
       return existsSync(dirname(clineExtensionConfigPath));
     },
@@ -340,6 +407,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "mcpServers",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
     detectGlobalInstall: async () => {
       return existsSync(dirname(clineCliConfigPath));
     },
@@ -355,9 +423,11 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "mcpServers",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: ["timeout"],
     detectGlobalInstall: async () => {
       return existsSync(join(home, ".claude"));
     },
+    transformConfig: transformStandardConfig,
   },
 
   "claude-desktop": {
@@ -368,11 +438,13 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "mcpServers",
     format: "json",
     supportedTransports: ["stdio"],
+    supportedFields: [],
     unsupportedTransportMessage:
       "Claude Desktop only supports local (stdio) servers via its config file. Add remote servers through Settings → Connectors in the app instead.",
     detectGlobalInstall: async () => {
       return existsSync(join(appSupport, "Claude"));
     },
+    transformConfig: transformStandardConfig,
   },
 
   codex: {
@@ -387,6 +459,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "mcp_servers",
     format: "toml",
     supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
     detectGlobalInstall: async () => {
       return existsSync(join(home, ".codex"));
     },
@@ -402,6 +475,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "mcpServers",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: ["scopes"],
     detectGlobalInstall: async () => {
       return existsSync(join(home, ".cursor"));
     },
@@ -417,9 +491,11 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "mcpServers",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: ["timeout", "scopes"],
     detectGlobalInstall: async () => {
       return existsSync(join(home, ".gemini"));
     },
+    transformConfig: transformGeminiConfig,
   },
 
   goose: {
@@ -430,6 +506,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "extensions",
     format: "yaml",
     supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
     detectGlobalInstall: async () => {
       return existsSync(gooseConfigPath);
     },
@@ -446,6 +523,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     localConfigKey: "servers",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
     detectGlobalInstall: async () => {
       return existsSync(dirname(copilotConfigPath));
     },
@@ -461,10 +539,12 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "mcpServers",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
     detectGlobalInstall: async () => {
       return existsSync(join(home, ".mcporter"));
     },
     resolveConfigPath: resolveMcporterConfigPath,
+    transformConfig: transformStandardConfig,
   },
 
   opencode: {
@@ -476,6 +556,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "mcp",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
     detectGlobalInstall: async () => {
       return existsSync(join(home, ".config", "opencode"));
     },
@@ -491,9 +572,11 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "servers",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
     detectGlobalInstall: async () => {
       return existsSync(vscodePath);
     },
+    transformConfig: transformStandardConfig,
   },
 
   windsurf: {
@@ -504,6 +587,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "mcpServers",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
     detectGlobalInstall: async () => {
       return existsSync(join(home, ".codeium", "windsurf"));
     },
@@ -522,6 +606,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "context_servers",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
     detectGlobalInstall: async () => {
       const configDir =
         process.platform === "darwin" || process.platform === "win32"

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import {
   resolveArrayTemplates,
   resolveRecordTemplates,
 } from "./template.js";
+import { describeOptionalField, type OptionalField } from "./schema.js";
 
 import packageJson from "../package.json" with { type: "json" };
 
@@ -155,6 +156,9 @@ interface Options {
   header?: string[];
   env?: string[];
   args?: string[];
+  timeout?: string;
+  scopes?: string;
+  oauthScopes?: string;
   yes?: boolean;
   all?: boolean;
   gitignore?: boolean;
@@ -448,6 +452,15 @@ program
     collect,
     [],
   )
+  .option(
+    "--timeout <ms>",
+    "Request timeout in milliseconds for remote servers. Only applied to agents that support it (e.g. Claude Code, Gemini CLI); dropped with a warning elsewhere.",
+  )
+  .option(
+    "--scopes <scopes>",
+    "OAuth scopes to request for remote servers (comma-separated). Only applied to agents that support it (e.g. Cursor, Gemini CLI); dropped with a warning elsewhere.",
+  )
+  .option("--oauth-scopes <scopes>", "Alias for --scopes")
   .option("-y, --yes", "Skip confirmation prompts")
   .option("--all", "Install to all agents")
   .option("--gitignore", "Add generated project config files to .gitignore")
@@ -1418,6 +1431,44 @@ async function main(target: string | undefined, options: Options) {
     }
   }
 
+  // Handle remote-only --timeout flag
+  let resolvedTimeout: number | undefined;
+  if (options.timeout !== undefined) {
+    const parsedTimeout = Number(options.timeout);
+    if (!Number.isInteger(parsedTimeout) || parsedTimeout <= 0) {
+      p.log.error(
+        `Invalid --timeout value: ${options.timeout}. Provide a positive integer (milliseconds).`,
+      );
+      process.exit(1);
+    }
+    if (isRemote) {
+      resolvedTimeout = parsedTimeout;
+    } else {
+      p.log.warn("--timeout is only used for remote URLs, ignoring");
+    }
+  }
+
+  // Handle remote-only --scopes / --oauth-scopes flag
+  const scopesValue = options.scopes ?? options.oauthScopes;
+  let resolvedScopes: string[] | undefined;
+  if (scopesValue !== undefined) {
+    const parsedScopes = scopesValue
+      .split(",")
+      .map((scope) => scope.trim())
+      .filter((scope) => scope.length > 0);
+    if (parsedScopes.length === 0) {
+      p.log.error(
+        `Invalid --scopes value: ${scopesValue}. Provide one or more comma-separated scopes.`,
+      );
+      process.exit(1);
+    }
+    if (isRemote) {
+      resolvedScopes = parsedScopes;
+    } else {
+      p.log.warn("--scopes is only used for remote URLs, ignoring");
+    }
+  }
+
   // Build server config
   const serverConfig = buildServerConfig(parsed, {
     transport: resolvedTransport,
@@ -1430,6 +1481,8 @@ async function main(target: string | undefined, options: Options) {
         ? envForConfig
         : undefined,
     args: argsForConfig && argsForConfig.length > 0 ? argsForConfig : undefined,
+    timeout: resolvedTimeout,
+    oauthScopes: resolvedScopes,
   });
 
   // Determine target agents
@@ -1790,6 +1843,25 @@ async function main(target: string | undefined, options: Options) {
         `  ${chalk.red("✗")} ${agent.displayName}: ${chalk.dim(result.error)}`,
       );
     }
+  }
+
+  // Surface any optional fields that were dropped because an agent can't
+  // represent them, grouped by field for a concise message.
+  const droppedByField = new Map<OptionalField, string[]>();
+  for (const [agentType, result] of results) {
+    for (const field of result.droppedFields ?? []) {
+      const agentNames = droppedByField.get(field) ?? [];
+      agentNames.push(agents[agentType].displayName);
+      droppedByField.set(field, agentNames);
+    }
+  }
+
+  for (const [field, agentNames] of droppedByField) {
+    p.log.warn(
+      `${describeOptionalField(field)} is not supported by ${agentNames.join(", ")}; dropped from ${
+        agentNames.length === 1 ? "that config" : "those configs"
+      }.`,
+    );
   }
 
   if (options.gitignore && options.global) {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -10,6 +10,7 @@ import type {
 import { agents } from "./agents.js";
 import { writeConfig, buildConfigWithKey } from "./formats/index.js";
 import { looksLikePath } from "./source-parser.js";
+import { applyFieldSupport, type OptionalField } from "./schema.js";
 
 export interface InstallOptions {
   /** Install to local (project-level) config instead of global */
@@ -29,6 +30,11 @@ export interface InstallResult {
   success: boolean;
   path: string;
   error?: string;
+  /**
+   * Optional fields that were requested but dropped because the target agent
+   * does not support them. Empty/undefined when nothing was dropped.
+   */
+  droppedFields?: OptionalField[];
 }
 
 export interface BuildServerConfigOptions {
@@ -40,6 +46,10 @@ export interface BuildServerConfigOptions {
   env?: Record<string, string>;
   /** Extra command arguments for local stdio servers */
   args?: string[];
+  /** Request timeout in milliseconds for remote servers */
+  timeout?: number;
+  /** OAuth scopes to request for remote servers */
+  oauthScopes?: string[];
 }
 
 export interface UpdateGitignoreOptions {
@@ -64,6 +74,14 @@ export function buildServerConfig(
 
     if (options.headers && Object.keys(options.headers).length > 0) {
       config.headers = options.headers;
+    }
+
+    if (typeof options.timeout === "number") {
+      config.timeout = options.timeout;
+    }
+
+    if (options.oauthScopes && options.oauthScopes.length > 0) {
+      config.oauthScopes = options.oauthScopes;
     }
 
     return config;
@@ -217,11 +235,18 @@ export function installServerForAgent(
       mkdirSync(dir, { recursive: true });
     }
 
-    const transformedConfig = agent.transformConfig
-      ? agent.transformConfig(serverName, serverConfig, {
-          local: Boolean(options.local),
-        })
-      : serverConfig;
+    // Strip optional fields the agent can't represent, then transform the
+    // gated config into the agent's native schema. Because every transform
+    // builds a fresh object with only known keys, unsupported fields can never
+    // leak into the written config.
+    const { config: gatedConfig, dropped } = applyFieldSupport(
+      serverConfig,
+      agent.supportedFields,
+    );
+
+    const transformedConfig = agent.transformConfig(serverName, gatedConfig, {
+      local: Boolean(options.local),
+    });
 
     const configKey = getConfigKey(agent, options);
     const config = buildConfigWithKey(configKey, serverName, transformedConfig);
@@ -231,6 +256,7 @@ export function installServerForAgent(
     return {
       success: true,
       path: configPath,
+      ...(dropped.length > 0 ? { droppedFields: dropped } : {}),
     };
   } catch (error) {
     return {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -21,10 +21,9 @@ export {
   getAgentTypes,
 } from "./agents.js";
 
-export {
-  type InstallOptions,
-  type InstallResult,
-} from "./installer.js";
+export { type InstallOptions, type InstallResult } from "./installer.js";
+
+export { type OptionalField } from "./schema.js";
 
 export {
   listInstalledServers,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,86 @@
+import type { McpServerConfig } from "./types.js";
+
+/**
+ * Optional, capability-gated fields on {@link McpServerConfig}.
+ *
+ * The canonical {@link McpServerConfig} is the single, agent-agnostic schema
+ * that the CLI and library populate. Not every MCP client understands every
+ * optional field, so each agent declares which of these it supports via
+ * `AgentConfig.supportedFields`. Anything an agent does not support is dropped
+ * before its transform runs, guaranteeing that only known fields are ever
+ * written to a client config.
+ */
+export type OptionalField = "timeout" | "scopes";
+
+interface OptionalFieldSpec {
+  /** Human-friendly label used in user-facing "dropped" warnings. */
+  label: string;
+  /** True when the canonical config carries a meaningful value for this field. */
+  isSet: (config: McpServerConfig) => boolean;
+  /** Remove the field from a config copy. Never mutates the caller's object. */
+  clear: (config: McpServerConfig) => void;
+}
+
+const OPTIONAL_FIELD_SPECS: Record<OptionalField, OptionalFieldSpec> = {
+  timeout: {
+    label: "request timeout",
+    isSet: (config) => typeof config.timeout === "number",
+    clear: (config) => {
+      delete config.timeout;
+    },
+  },
+  scopes: {
+    label: "OAuth scopes",
+    isSet: (config) =>
+      Array.isArray(config.oauthScopes) && config.oauthScopes.length > 0,
+    clear: (config) => {
+      delete config.oauthScopes;
+    },
+  },
+};
+
+const ALL_OPTIONAL_FIELDS = Object.keys(
+  OPTIONAL_FIELD_SPECS,
+) as OptionalField[];
+
+export function describeOptionalField(field: OptionalField): string {
+  return OPTIONAL_FIELD_SPECS[field].label;
+}
+
+export interface FieldSupportResult {
+  /** A copy of the input with unsupported optional fields removed. */
+  config: McpServerConfig;
+  /** Optional fields that were set but dropped because the agent lacks support. */
+  dropped: OptionalField[];
+}
+
+/**
+ * Produce an agent-ready copy of `config` containing only the optional fields
+ * the agent supports, alongside the list of fields that were dropped.
+ *
+ * The input is never mutated — {@link installServerForAgent} reuses one
+ * canonical config across many agents, so each agent must gate against its own
+ * copy.
+ */
+export function applyFieldSupport(
+  config: McpServerConfig,
+  supportedFields: readonly OptionalField[],
+): FieldSupportResult {
+  const supported = new Set(supportedFields);
+  const copy: McpServerConfig = { ...config };
+
+  // Defensively clone the containers we might clear so we never touch the
+  // caller's nested objects/arrays.
+  if (copy.oauthScopes) copy.oauthScopes = [...copy.oauthScopes];
+
+  const dropped: OptionalField[] = [];
+  for (const field of ALL_OPTIONAL_FIELDS) {
+    const spec = OPTIONAL_FIELD_SPECS[field];
+    if (spec.isSet(copy) && !supported.has(field)) {
+      spec.clear(copy);
+      dropped.push(field);
+    }
+  }
+
+  return { config: copy, dropped };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { OptionalField } from "./schema.js";
+
 export type AgentType =
   | "antigravity"
   | "cline"
@@ -44,6 +46,14 @@ export interface AgentConfig {
   format: ConfigFormat;
   /** Supported transport types for this agent */
   supportedTransports: ("stdio" | "sse" | "http")[];
+  /**
+   * Optional, capability-gated server fields this agent understands (e.g.
+   * `timeout`, `scopes`). Any optional field not listed here is stripped from
+   * the canonical config before {@link transformConfig} runs, so a client never
+   * receives a field it cannot interpret. Use an empty array for agents that
+   * only support the core fields.
+   */
+  supportedFields: OptionalField[];
   /** Shown when a user tries to use an unsupported transport */
   unsupportedTransportMessage?: string;
   /** Function to detect if agent is installed globally */
@@ -53,8 +63,13 @@ export interface AgentConfig {
     agent: AgentConfig,
     options: { local: boolean; cwd: string },
   ) => string;
-  /** Optional function to transform server config to agent-specific format */
-  transformConfig?: (
+  /**
+   * Transform the canonical, field-gated server config into this agent's
+   * concrete on-disk schema. Required for every agent: transforms must build a
+   * fresh object with only the keys the client understands, which structurally
+   * guarantees no unknown fields leak into a written config.
+   */
+  transformConfig: (
     serverName: string,
     config: McpServerConfig,
     context?: { local: boolean },
@@ -82,6 +97,17 @@ export interface McpServerConfig {
   command?: string;
   args?: string[];
   env?: Record<string, string>;
+  /**
+   * Request timeout in milliseconds for remote servers. Capability-gated:
+   * only emitted for agents that list `"timeout"` in `supportedFields`.
+   */
+  timeout?: number;
+  /**
+   * OAuth scopes to request for remote servers. Capability-gated: only emitted
+   * for agents that list `"scopes"` in `supportedFields`, each mapping it into
+   * their own native shape (e.g. Cursor `auth.scopes`, Gemini `oauth.scopes`).
+   */
+  oauthScopes?: string[];
 }
 
 export interface ConfigFile {

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -98,7 +98,39 @@ test("All agents have required properties", () => {
       typeof config.detectGlobalInstall === "function",
       `${type} missing detectGlobalInstall`,
     );
+    assert.ok(
+      Array.isArray(config.supportedFields),
+      `${type} missing supportedFields`,
+    );
+    assert.ok(
+      typeof config.transformConfig === "function",
+      `${type} missing required transformConfig`,
+    );
   }
+});
+
+test("Every agent declares a transformConfig so no raw config can leak", () => {
+  // transformConfig is required: a missing transform used to mean the raw
+  // McpServerConfig was written verbatim, which could leak unknown fields.
+  for (const type of getAgentTypes()) {
+    assert.strictEqual(
+      typeof agents[type].transformConfig,
+      "function",
+      `${type} must define transformConfig`,
+    );
+  }
+});
+
+test("supportedFields reflects per-client capabilities", () => {
+  assert.deepStrictEqual(agents.cursor.supportedFields, ["scopes"]);
+  assert.deepStrictEqual(agents["gemini-cli"].supportedFields, [
+    "timeout",
+    "scopes",
+  ]);
+  assert.deepStrictEqual(agents["claude-code"].supportedFields, ["timeout"]);
+  // Clients with no extra field support declare an empty list.
+  assert.deepStrictEqual(agents.vscode.supportedFields, []);
+  assert.deepStrictEqual(agents["claude-desktop"].supportedFields, []);
 });
 
 // ============================================

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -1290,6 +1290,103 @@ test("sync: prints already in sync when nothing to change", () => {
   assert.match(output, /already in sync/i);
 });
 
+test("E2E CLI: --timeout and --scopes map per agent and warn on drop", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "gemini-cli",
+      "-a",
+      "cursor",
+      "-a",
+      "vscode",
+      "-y",
+      "--name",
+      "scoped",
+      "--timeout",
+      "30000",
+      "--scopes",
+      "read,write",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  // Gemini: timeout + oauth.scopes
+  const gemini = JSON.parse(
+    readFileSync(join(projectDir, ".gemini", "settings.json"), "utf-8"),
+  );
+  const geminiServer = gemini.mcpServers.scoped as Record<string, unknown>;
+  assert.strictEqual(geminiServer.timeout, 30000);
+  assert.deepStrictEqual(geminiServer.oauth, { scopes: ["read", "write"] });
+
+  // Cursor: scopes -> auth.scopes, timeout dropped
+  const cursor = JSON.parse(
+    readFileSync(join(projectDir, ".cursor", "mcp.json"), "utf-8"),
+  );
+  const cursorServer = cursor.mcpServers.scoped as Record<string, unknown>;
+  assert.deepStrictEqual(cursorServer.auth, { scopes: ["read", "write"] });
+  assert.ok(!("timeout" in cursorServer));
+
+  // VS Code: both dropped, no raw fields
+  const vscode = JSON.parse(
+    readFileSync(join(projectDir, ".vscode", "mcp.json"), "utf-8"),
+  );
+  const vscodeServer = vscode.servers.scoped as Record<string, unknown>;
+  assert.ok(!("timeout" in vscodeServer));
+  assert.ok(!("oauthScopes" in vscodeServer));
+  assert.ok(!("auth" in vscodeServer));
+
+  // User is warned about dropped fields
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /request timeout is not supported by/i);
+  assert.match(output, /OAuth scopes is not supported by/i);
+});
+
+test("E2E CLI: --timeout with a package install warns and is ignored", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "mcp-server-postgres",
+      "-a",
+      "claude-code",
+      "-y",
+      "--name",
+      "pg",
+      "--timeout",
+      "5000",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const saved = JSON.parse(
+    readFileSync(join(projectDir, ".mcp.json"), "utf-8"),
+  );
+  const server = saved.mcpServers.pg as Record<string, unknown>;
+  assert.ok(!("timeout" in server), "timeout is remote-only");
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /--timeout is only used for remote URLs/i);
+});
+
 cleanup();
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -20,10 +20,12 @@ import { join } from "node:path";
 import {
   buildServerConfig,
   installServer,
+  installServerForAgent,
   updateGitignoreWithPaths,
 } from "../src/installer.js";
 import { agents } from "../src/agents.js";
 import { parseSource } from "../src/source-parser.js";
+import { applyFieldSupport } from "../src/schema.js";
 import type { AgentType } from "../src/types.js";
 
 let passed = 0;
@@ -349,6 +351,167 @@ test("buildServerConfig - remote source ignores env", () => {
   assert.strictEqual(config.url, "https://mcp.example.com/api");
   assert.strictEqual(config.env, undefined);
   assert.strictEqual(config.args, undefined);
+});
+
+test("buildServerConfig - remote stores timeout and oauthScopes", () => {
+  const parsed = parseSource("https://mcp.example.com/mcp");
+  const config = buildServerConfig(parsed, {
+    timeout: 30000,
+    oauthScopes: ["read", "write"],
+  });
+
+  assert.strictEqual(config.timeout, 30000);
+  assert.deepStrictEqual(config.oauthScopes, ["read", "write"]);
+});
+
+test("buildServerConfig - package ignores timeout and oauthScopes", () => {
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed, {
+    timeout: 30000,
+    oauthScopes: ["read"],
+  });
+
+  assert.strictEqual(config.timeout, undefined);
+  assert.strictEqual(config.oauthScopes, undefined);
+});
+
+// ============================================
+// Capability gating (applyFieldSupport)
+// ============================================
+
+test("applyFieldSupport - drops unsupported optional fields without mutating input", () => {
+  const original = {
+    type: "http" as const,
+    url: "https://mcp.example.com/mcp",
+    timeout: 30000,
+    oauthScopes: ["read", "write"],
+  };
+
+  const { config, dropped } = applyFieldSupport(original, ["scopes"]);
+
+  // timeout dropped (unsupported), scopes kept (supported)
+  assert.strictEqual(config.timeout, undefined);
+  assert.deepStrictEqual(config.oauthScopes, ["read", "write"]);
+  assert.deepStrictEqual(dropped, ["timeout"]);
+
+  // Input object is never mutated (it is reused across agents)
+  assert.strictEqual(original.timeout, 30000);
+  assert.deepStrictEqual(original.oauthScopes, ["read", "write"]);
+});
+
+test("applyFieldSupport - keeps all fields when fully supported", () => {
+  const { config, dropped } = applyFieldSupport(
+    {
+      type: "http",
+      url: "https://mcp.example.com/mcp",
+      timeout: 5000,
+      oauthScopes: ["read"],
+    },
+    ["timeout", "scopes"],
+  );
+
+  assert.strictEqual(config.timeout, 5000);
+  assert.deepStrictEqual(config.oauthScopes, ["read"]);
+  assert.deepStrictEqual(dropped, []);
+});
+
+// ============================================
+// Per-agent optional field mapping (no leaks)
+// ============================================
+
+function installRemoteWith(
+  agentType: AgentType,
+  tempDir: string,
+  extra: { timeout?: number; oauthScopes?: string[] },
+) {
+  const parsed = parseSource("https://mcp.example.com/mcp");
+  const config = buildServerConfig(parsed, extra);
+  return installServerForAgent("example", config, agentType, {
+    local: true,
+    cwd: tempDir,
+  });
+}
+
+test("installServerForAgent - Cursor maps scopes to auth.scopes", () => {
+  const tempDir = createTempDir();
+  const result = installRemoteWith("cursor", tempDir, {
+    oauthScopes: ["read", "write"],
+    timeout: 30000,
+  });
+  assert.ok(result.success);
+  // Cursor supports scopes but not timeout
+  assert.deepStrictEqual(result.droppedFields, ["timeout"]);
+
+  const saved = readJsonConfig(join(tempDir, ".cursor", "mcp.json"));
+  const server = (saved.mcpServers as Record<string, Record<string, unknown>>)
+    .example;
+  assert.ok(server);
+  assert.deepStrictEqual(server.auth, { scopes: ["read", "write"] });
+  assert.ok(!("timeout" in server), "timeout must not leak into Cursor config");
+  assert.ok(
+    !("oauthScopes" in server),
+    "raw oauthScopes must never be written",
+  );
+});
+
+test("installServerForAgent - Gemini maps scopes to oauth.scopes and keeps timeout", () => {
+  const tempDir = createTempDir();
+  const result = installRemoteWith("gemini-cli", tempDir, {
+    oauthScopes: ["https://example.com/scope"],
+    timeout: 30000,
+  });
+  assert.ok(result.success);
+  assert.strictEqual(result.droppedFields, undefined);
+
+  const saved = readJsonConfig(join(tempDir, ".gemini", "settings.json"));
+  const server = (saved.mcpServers as Record<string, Record<string, unknown>>)
+    .example;
+  assert.ok(server);
+  assert.deepStrictEqual(server.oauth, {
+    scopes: ["https://example.com/scope"],
+  });
+  assert.strictEqual(server.timeout, 30000);
+  assert.ok(
+    !("oauthScopes" in server),
+    "raw oauthScopes must never be written",
+  );
+});
+
+test("installServerForAgent - Claude Code keeps timeout, drops scopes", () => {
+  const tempDir = createTempDir();
+  const result = installRemoteWith("claude-code", tempDir, {
+    oauthScopes: ["read"],
+    timeout: 12000,
+  });
+  assert.ok(result.success);
+  assert.deepStrictEqual(result.droppedFields, ["scopes"]);
+
+  const saved = readJsonConfig(join(tempDir, ".mcp.json"));
+  const server = (saved.mcpServers as Record<string, Record<string, unknown>>)
+    .example;
+  assert.ok(server);
+  assert.strictEqual(server.timeout, 12000);
+  assert.ok(!("auth" in server));
+  assert.ok(!("oauth" in server));
+  assert.ok(!("oauthScopes" in server));
+});
+
+test("installServerForAgent - VS Code drops both timeout and scopes", () => {
+  const tempDir = createTempDir();
+  const result = installRemoteWith("vscode", tempDir, {
+    oauthScopes: ["read"],
+    timeout: 12000,
+  });
+  assert.ok(result.success);
+  assert.deepStrictEqual(result.droppedFields, ["timeout", "scopes"]);
+
+  const saved = readJsonConfig(join(tempDir, ".vscode", "mcp.json"));
+  const server = (saved.servers as Record<string, Record<string, unknown>>)
+    .example;
+  assert.ok(server);
+  assert.strictEqual(server.url, "https://mcp.example.com/mcp");
+  assert.ok(!("timeout" in server));
+  assert.ok(!("oauthScopes" in server));
 });
 
 // ============================================


### PR DESCRIPTION
## Summary

Adds opt-in `--timeout <ms>` and `--scopes <scopes>` (alias `--oauth-scopes`) flags for remote MCP servers, and hardens config writing so only known fields are ever emitted.

Closes the actionable, cross-client part of #51.

### What's new

- **`--timeout <ms>`** and **`--scopes <scopes>`** flags (remote-only; warn + ignore for stdio/package installs).
- Both are stored on the canonical `McpServerConfig` and **capability-gated per agent** via a new `supportedFields` declaration, mapped into each client's native shape:

  | Field | Supported by | Mapped to |
  |---|---|---|
  | `timeout` | Claude Code, Gemini CLI | `timeout` (ms) |
  | `scopes` | Cursor, Gemini CLI | Cursor `auth.scopes`, Gemini `oauth.scopes` |

- When a targeted agent doesn't support a field, it's **dropped with a grouped warning** (e.g. _"request timeout is not supported by VS Code; dropped from that config."_) while other agents still receive it. `InstallResult` now carries `droppedFields` for programmatic consumers.

### Hardening: no more raw-config leaks

`transformConfig` is now **required for every agent**. Previously Claude Code, Claude Desktop, Gemini CLI, VS Code, and mcporter had no transform and wrote the raw `McpServerConfig` verbatim — which would have leaked these new (and any future) fields. Each now builds a fresh object containing only the keys that client understands (the Cursor stdio branch had the same issue and is fixed). Field gating runs centrally in `installServerForAgent` against the new `src/schema.ts` capability layer, so the canonical schema is the single source of truth.

### Deliberately out of scope

`authProviderType` (from the #51 example) is **not** added: it's Gemini/Google-specific (`google_credentials` / `service_account_impersonation`) and not part of the MCP spec, so it doesn't belong on a shared, cross-client field surface. It could be added later as a Gemini-only option if there's demand.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test` — full suite green (unit + e2e), including new coverage:
  - `applyFieldSupport` gating + non-mutation of the shared canonical config
  - per-agent mapping for Cursor / Gemini / Claude Code / VS Code (and assertions that raw `oauthScopes`/`timeout` never leak)
  - every agent declares `transformConfig` + `supportedFields`
  - e2e CLI: multi-agent install maps/drops fields and prints warnings; `--timeout` on a package install warns and is ignored
- [x] `bun run build` succeeds