### PR TITLE
feat: --auto-approve / --approve-tool for Codex and Claude Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.12.0] - 2026-06-21
+
+- add `--auto-approve` and repeatable `--approve-tool <tool>` to preconfigure agent-level MCP tool approval. Capability-gated per client and mapped to each client's native mechanism: Codex writes approval modes to `config.toml` (`tools.<name>.approval_mode = "approve"`, or `default_tools_approval_mode` for all tools); Claude Code writes permission allow rules (`mcp__<server>__<tool>`, or `mcp__<server>` for all tools) to a separate settings file (`.claude/settings.local.json` for project installs, `~/.claude/settings.json` for global) while keeping the MCP server entry clean. Agents that don't support auto-approval have it dropped with a warning. Co-authored with @RhysSullivan ([#32](https://github.com/neon-solutions/add-mcp/pull/32))
+
 ## [1.11.0] - 2026-06-20
 
 - add `--timeout <ms>` and `--scopes <scopes>` (alias `--oauth-scopes`) flags for remote servers. Fields are capability-gated per client and mapped to each client's native shape: `--timeout` → Claude Code / Gemini CLI `timeout`; `--scopes` → Cursor `auth.scopes` and Gemini CLI `oauth.scopes`. Agents that don't support a field have it dropped with a warning, so other agents still receive it ([#51](https://github.com/neon-solutions/add-mcp/issues/51))

--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ npx add-mcp https://mcp.example.com/mcp --header "Authorization: Bearer $TOKEN"
 # (each agent only keeps the fields it supports; others are dropped with a warning)
 npx add-mcp https://mcp.example.com/mcp --timeout 30000 --scopes "read,write"
 
+# Auto-approve all tools for agents that support it (Codex, Claude Code)
+npx add-mcp "executor mcp" --name executor -a codex -a claude-code --auto-approve
+
+# Auto-approve only selected tools
+npx add-mcp "executor mcp" --name executor -a codex --auto-approve --approve-tool execute
+
 # npm package (runs via npx)
 npx add-mcp @modelcontextprotocol/server-postgres
 
@@ -164,21 +170,23 @@ npx add-mcp https://mcp.example.com/mcp -a cursor -y --gitignore
 
 ### Options
 
-| Option                   | Description                                                              |
-| ------------------------ | ------------------------------------------------------------------------ |
-| `-g, --global`           | Install to user directory instead of project                             |
-| `-a, --agent <agent>`    | Target specific agents (e.g., `cursor`, `claude-code`). Can be repeated. |
-| `-t, --transport <type>` | Transport type for remote servers: `http` (default), `sse`               |
-| `--type <type>`          | Alias for `--transport`                                                  |
-| `-h, --header <header>`  | HTTP header for remote servers (repeatable, `Key: Value`)                |
-| `--env <env>`            | Env var for local stdio servers (repeatable, `KEY=VALUE`)                |
-| `--timeout <ms>`         | Request timeout (ms) for remote servers (capability-gated, see below)    |
-| `--scopes <scopes>`      | OAuth scopes for remote servers, comma-separated (capability-gated)      |
-| `--oauth-scopes <scopes>`| Alias for `--scopes`                                                     |
-| `-n, --name <name>`      | Server name (auto-inferred if not provided)                              |
-| `-y, --yes`              | Skip all confirmation prompts                                            |
-| `--all`                  | Install to all agents                                                    |
-| `--gitignore`            | Add generated config files to `.gitignore`                               |
+| Option                    | Description                                                              |
+| ------------------------- | ------------------------------------------------------------------------ |
+| `-g, --global`            | Install to user directory instead of project                             |
+| `-a, --agent <agent>`     | Target specific agents (e.g., `cursor`, `claude-code`). Can be repeated. |
+| `-t, --transport <type>`  | Transport type for remote servers: `http` (default), `sse`               |
+| `--type <type>`           | Alias for `--transport`                                                  |
+| `-h, --header <header>`   | HTTP header for remote servers (repeatable, `Key: Value`)                |
+| `--env <env>`             | Env var for local stdio servers (repeatable, `KEY=VALUE`)                |
+| `--timeout <ms>`          | Request timeout (ms) for remote servers (capability-gated, see below)    |
+| `--scopes <scopes>`       | OAuth scopes for remote servers, comma-separated (capability-gated)      |
+| `--oauth-scopes <scopes>` | Alias for `--scopes`                                                     |
+| `--auto-approve`          | Auto-approve MCP tool calls for supported agents (Codex, Claude Code)    |
+| `--approve-tool <tool>`   | Tool to auto-approve with `--auto-approve` (repeatable; defaults to all) |
+| `-n, --name <name>`       | Server name (auto-inferred if not provided)                              |
+| `-y, --yes`               | Skip all confirmation prompts                                            |
+| `--all`                   | Install to all agents                                                    |
+| `--gitignore`             | Add generated config files to `.gitignore`                               |
 
 #### Capability-gated fields (`--timeout`, `--scopes`)
 
@@ -186,15 +194,36 @@ Not every MCP client understands every field. `add-mcp` keeps one canonical
 server config and each agent declares which optional fields it supports, mapping
 them into that client's native shape:
 
-| Field      | Flag             | Supported by                | Mapped to                          |
-| ---------- | ---------------- | --------------------------- | ---------------------------------- |
-| Timeout    | `--timeout`      | Claude Code, Gemini CLI     | `timeout` (milliseconds)           |
-| OAuth scopes | `--scopes`     | Cursor, Gemini CLI          | Cursor `auth.scopes`, Gemini `oauth.scopes` |
+| Field              | Flag                                | Supported by            | Mapped to                                                |
+| ------------------ | ----------------------------------- | ----------------------- | -------------------------------------------------------- |
+| Timeout            | `--timeout`                         | Claude Code, Gemini CLI | `timeout` (milliseconds)                                 |
+| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI      | Cursor `auth.scopes`, Gemini `oauth.scopes`              |
+| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code      | Codex approval modes; Claude Code permission allow rules |
 
 When you target an agent that does not support a field, `add-mcp` drops it from
 that agent's config and prints a warning (e.g. _"request timeout is not
 supported by VS Code; dropped from that config."_). Other agents still receive
-it. Both flags apply to remote servers only.
+it. `--timeout` and `--scopes` apply to remote servers only; `--auto-approve`
+applies to both remote and local servers.
+
+#### Auto-approving tool calls (`--auto-approve`)
+
+`--auto-approve` preconfigures agent-level approval so the agent doesn't prompt
+before each MCP tool call — useful for servers that already gate actions
+internally. Use `--approve-tool <name>` (repeatable) to approve only specific
+tools; without it, all tools are approved.
+
+- **Codex** — writes approval modes into `config.toml`: per-tool
+  `tools.<name>.approval_mode = "approve"`, or `default_tools_approval_mode = "approve"` for all tools.
+- **Claude Code** — writes permission allow rules to a separate settings file
+  (`.claude/settings.local.json` for project installs, `~/.claude/settings.json`
+  for global), e.g. `mcp__<server>__<tool>`, or `mcp__<server>` for all tools.
+  The MCP server entry itself stays clean.
+
+> Note: Claude Code's all-tools rule (`mcp__<server>`) follows the documented
+> format, but a known Claude Code bug ([#34739](https://github.com/anthropics/claude-code/issues/34739))
+> can still prompt for non-fully-qualified MCP rules. Listing tools explicitly
+> with `--approve-tool` is the most reliable path there.
 
 ### Transport Types
 
@@ -232,14 +261,16 @@ npx add-mcp find github --all --gitignore
 
 ### Options
 
-| Option                | Description                                                              |
-| --------------------- | ------------------------------------------------------------------------ |
-| `-g, --global`        | Install to user directory instead of project                             |
-| `-a, --agent <agent>` | Target specific agents (e.g., `cursor`, `claude-code`). Can be repeated. |
-| `-n, --name <name>`   | Server name override (defaults to the selected catalog entry name)       |
-| `-y, --yes`           | Skip confirmation prompts                                                |
-| `--all`               | Install to all agents                                                    |
-| `--gitignore`         | Add generated config files to `.gitignore`                               |
+| Option                  | Description                                                              |
+| ----------------------- | ------------------------------------------------------------------------ |
+| `-g, --global`          | Install to user directory instead of project                             |
+| `-a, --agent <agent>`   | Target specific agents (e.g., `cursor`, `claude-code`). Can be repeated. |
+| `-n, --name <name>`     | Server name override (defaults to the selected catalog entry name)       |
+| `-y, --yes`             | Skip confirmation prompts                                                |
+| `--auto-approve`        | Auto-approve MCP tool calls for supported agents (Codex, Claude Code)    |
+| `--approve-tool <tool>` | Tool to auto-approve with `--auto-approve` (repeatable; defaults to all) |
+| `--all`                 | Install to all agents                                                    |
+| `--gitignore`           | Add generated config files to `.gitignore`                               |
 
 Transport for `find`/`search` is inferred from registry metadata. The CLI prefers HTTP remotes when available and only falls back to SSE when HTTP is not available for the selected install context.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -204,6 +204,30 @@ function transformOpenCodeConfig(
   };
 }
 
+/**
+ * Apply Codex MCP approval config to a server table. Codex resolves approval
+ * per-tool first, then falls back to the server-level default:
+ *   - all tools  -> `default_tools_approval_mode = "approve"`
+ *   - some tools -> `tools.<name>.approval_mode = "approve"`
+ * See https://developers.openai.com/codex/mcp.
+ */
+function applyCodexApproval(
+  target: Record<string, unknown>,
+  autoApproveTools: string[] | undefined,
+): Record<string, unknown> {
+  if (!autoApproveTools) return target;
+
+  if (autoApproveTools.length === 0) {
+    target.default_tools_approval_mode = "approve";
+    return target;
+  }
+
+  target.tools = Object.fromEntries(
+    autoApproveTools.map((tool) => [tool, { approval_mode: "approve" }]),
+  );
+  return target;
+}
+
 function transformCodexConfig(
   _serverName: string,
   config: McpServerConfig,
@@ -218,14 +242,17 @@ function transformCodexConfig(
       remoteConfig.http_headers = config.headers;
     }
 
-    return remoteConfig;
+    return applyCodexApproval(remoteConfig, config.autoApproveTools);
   }
 
-  return {
-    command: config.command,
-    args: config.args || [],
-    env: config.env,
-  };
+  return applyCodexApproval(
+    {
+      command: config.command,
+      args: config.args || [],
+      env: config.env,
+    },
+    config.autoApproveTools,
+  );
 }
 
 function transformCursorConfig(
@@ -423,7 +450,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "mcpServers",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
-    supportedFields: ["timeout"],
+    supportedFields: ["timeout", "autoApprove"],
     detectGlobalInstall: async () => {
       return existsSync(join(home, ".claude"));
     },
@@ -459,7 +486,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "mcp_servers",
     format: "toml",
     supportedTransports: ["stdio", "http", "sse"],
-    supportedFields: [],
+    supportedFields: ["autoApprove"],
     detectGlobalInstall: async () => {
       return existsSync(join(home, ".codex"));
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,6 +159,8 @@ interface Options {
   timeout?: string;
   scopes?: string;
   oauthScopes?: string;
+  autoApprove?: boolean;
+  approveTool?: string[];
   yes?: boolean;
   all?: boolean;
   gitignore?: boolean;
@@ -244,6 +246,25 @@ function extractSubcommandOptionsFromArgv(): Partial<Options> {
     }
     if (arg === "--gitignore") {
       result.gitignore = true;
+      continue;
+    }
+    if (arg === "--auto-approve") {
+      result.autoApprove = true;
+      continue;
+    }
+    if (arg === "--approve-tool") {
+      const tools: string[] = result.approveTool ? [...result.approveTool] : [];
+      let j = i + 1;
+      while (j < argv.length) {
+        const value = argv[j];
+        if (!value || value.startsWith("-")) break;
+        tools.push(value);
+        j += 1;
+      }
+      if (tools.length > 0) {
+        result.approveTool = tools;
+      }
+      i = j - 1;
       continue;
     }
     if ((arg === "-h" || arg === "--header") && argv[i + 1]) {
@@ -461,6 +482,16 @@ program
     "OAuth scopes to request for remote servers (comma-separated). Only applied to agents that support it (e.g. Cursor, Gemini CLI); dropped with a warning elsewhere.",
   )
   .option("--oauth-scopes <scopes>", "Alias for --scopes")
+  .option(
+    "--auto-approve",
+    "Auto-approve MCP tool calls for agents that support it (Codex, Claude Code). Dropped with a warning for other agents.",
+  )
+  .option(
+    "--approve-tool <tool>",
+    "Tool name to auto-approve when --auto-approve is set (repeatable; defaults to all tools)",
+    collect,
+    [],
+  )
   .option("-y, --yes", "Skip confirmation prompts")
   .option("--all", "Install to all agents")
   .option("--gitignore", "Add generated project config files to .gitignore")
@@ -535,6 +566,16 @@ program
     "Server name override (defaults to catalog entry name)",
   )
   .option("-y, --yes", "Skip confirmation prompts")
+  .option(
+    "--auto-approve",
+    "Auto-approve MCP tool calls for agents that support it (Codex, Claude Code)",
+  )
+  .option(
+    "--approve-tool <tool>",
+    "Tool name to auto-approve when --auto-approve is set (repeatable; defaults to all tools)",
+    collect,
+    [],
+  )
   .option("--all", "Install to all agents")
   .option("--gitignore", "Add generated project config files to .gitignore")
   .action(
@@ -559,6 +600,16 @@ program
     "Server name override (defaults to catalog entry name)",
   )
   .option("-y, --yes", "Skip confirmation prompts")
+  .option(
+    "--auto-approve",
+    "Auto-approve MCP tool calls for agents that support it (Codex, Claude Code)",
+  )
+  .option(
+    "--approve-tool <tool>",
+    "Tool name to auto-approve when --auto-approve is set (repeatable; defaults to all tools)",
+    collect,
+    [],
+  )
   .option("--all", "Install to all agents")
   .option("--gitignore", "Add generated project config files to .gitignore")
   .action(
@@ -1469,6 +1520,12 @@ async function main(target: string | undefined, options: Options) {
     }
   }
 
+  // Handle --auto-approve / --approve-tool (applies to remote and local).
+  // An empty list means "all tools"; --approve-tool implies --auto-approve.
+  const approveTools = [...new Set(options.approveTool ?? [])];
+  const autoApproveTools =
+    options.autoApprove || approveTools.length > 0 ? approveTools : undefined;
+
   // Build server config
   const serverConfig = buildServerConfig(parsed, {
     transport: resolvedTransport,
@@ -1483,6 +1540,7 @@ async function main(target: string | undefined, options: Options) {
     args: argsForConfig && argsForConfig.length > 0 ? argsForConfig : undefined,
     timeout: resolvedTimeout,
     oauthScopes: resolvedScopes,
+    autoApproveTools,
   });
 
   // Determine target agents
@@ -1753,6 +1811,15 @@ async function main(target: string | undefined, options: Options) {
   const summaryLines: string[] = [];
   summaryLines.push(`${chalk.cyan("Server:")} ${serverName}`);
   summaryLines.push(`${chalk.cyan("Type:")} ${sourceType}`);
+  if (autoApproveTools) {
+    summaryLines.push(
+      `${chalk.cyan("Auto-approve:")} ${
+        autoApproveTools.length === 0
+          ? "All tools"
+          : autoApproveTools.join(", ")
+      }`,
+    );
+  }
 
   // Determine scope display
   const localAgents = targetAgents.filter(
@@ -1820,6 +1887,11 @@ async function main(target: string | undefined, options: Options) {
       resultLines.push(
         `${chalk.green("✓")} ${agent.displayName}: ${chalk.dim(shortPath)}`,
       );
+      for (const extraPath of result.extraPaths ?? []) {
+        resultLines.push(
+          `  ${chalk.dim("↳ permissions:")} ${chalk.dim(shortenPath(extraPath))}`,
+        );
+      }
     }
 
     p.note(
@@ -1869,7 +1941,10 @@ async function main(target: string | undefined, options: Options) {
       "--gitignore is only supported for project-scoped installations; ignoring.",
     );
   } else if (options.gitignore) {
-    const successfulPaths = successful.map(([_, result]) => result.path);
+    const successfulPaths = successful.flatMap(([_, result]) => [
+      result.path,
+      ...(result.extraPaths ?? []),
+    ]);
     const gitignoreUpdate = updateGitignoreWithPaths(successfulPaths);
     if (gitignoreUpdate.added.length > 0) {
       p.log.info(

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
 import { join, dirname, isAbsolute, relative, sep } from "path";
 import type {
   AgentType,
@@ -11,6 +12,8 @@ import { agents } from "./agents.js";
 import { writeConfig, buildConfigWithKey } from "./formats/index.js";
 import { looksLikePath } from "./source-parser.js";
 import { applyFieldSupport, type OptionalField } from "./schema.js";
+
+const home = homedir();
 
 export interface InstallOptions {
   /** Install to local (project-level) config instead of global */
@@ -35,6 +38,12 @@ export interface InstallResult {
    * does not support them. Empty/undefined when nothing was dropped.
    */
   droppedFields?: OptionalField[];
+  /**
+   * Additional files written beyond the main config (e.g. a Claude Code
+   * permissions settings file for auto-approval). Surfaced so the CLI can
+   * report them and include them in `--gitignore`.
+   */
+  extraPaths?: string[];
 }
 
 export interface BuildServerConfigOptions {
@@ -50,6 +59,11 @@ export interface BuildServerConfigOptions {
   timeout?: number;
   /** OAuth scopes to request for remote servers */
   oauthScopes?: string[];
+  /**
+   * Tools to auto-approve for agents that support it. An empty array means
+   * "all tools". Applies to remote and local servers alike.
+   */
+  autoApproveTools?: string[];
 }
 
 export interface UpdateGitignoreOptions {
@@ -84,6 +98,10 @@ export function buildServerConfig(
       config.oauthScopes = options.oauthScopes;
     }
 
+    if (options.autoApproveTools) {
+      config.autoApproveTools = options.autoApproveTools;
+    }
+
     return config;
   }
 
@@ -113,6 +131,10 @@ export function buildServerConfig(
       config.env = options.env;
     }
 
+    if (options.autoApproveTools) {
+      config.autoApproveTools = options.autoApproveTools;
+    }
+
     return config;
   }
 
@@ -125,7 +147,111 @@ export function buildServerConfig(
     config.env = options.env;
   }
 
+  if (options.autoApproveTools) {
+    config.autoApproveTools = options.autoApproveTools;
+  }
+
   return config;
+}
+
+function readJsonObject(filePath: string): Record<string, unknown> {
+  if (!existsSync(filePath)) {
+    return {};
+  }
+  const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as unknown;
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : {};
+}
+
+function writeJsonObject(
+  filePath: string,
+  value: Record<string, unknown>,
+): void {
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
+function addUniqueStrings(existing: unknown, additions: string[]): string[] {
+  const values = Array.isArray(existing)
+    ? existing.filter((value): value is string => typeof value === "string")
+    : [];
+  for (const addition of additions) {
+    if (!values.includes(addition)) {
+      values.push(addition);
+    }
+  }
+  return values;
+}
+
+/**
+ * Claude Code permission allow rules for auto-approval. An empty `tools` list
+ * means "all tools from this server" (`mcp__<server>`); otherwise each tool is
+ * its own fully-qualified rule (`mcp__<server>__<tool>`).
+ *
+ * Note: the all-tools form (`mcp__<server>`) is the documented Claude Code
+ * format, but there is a known Claude Code bug where non-fully-qualified MCP
+ * rules may still prompt at runtime (anthropics/claude-code#34739). Per-tool
+ * rules are the reliable path; we still emit the documented all-tools rule for
+ * `--auto-approve` without specific tools.
+ */
+function claudeAutoApproveRules(serverName: string, tools: string[]): string[] {
+  if (tools.length === 0) {
+    return [`mcp__${serverName}`];
+  }
+  return tools.map((tool) => `mcp__${serverName}__${tool}`);
+}
+
+function getClaudeCodeSettingsPath(options: InstallOptions = {}): string {
+  const local = Boolean(options.local);
+  const cwd = options.cwd || process.cwd();
+  // Local installs use the personal, git-ignored settings.local.json so a
+  // contributor's auto-approval choices aren't committed for the whole team.
+  return local
+    ? join(cwd, ".claude", "settings.local.json")
+    : join(home, ".claude", "settings.json");
+}
+
+interface ClaudeApprovalResult {
+  success: boolean;
+  path: string;
+  error?: string;
+}
+
+function installClaudeCodeAutoApproval(
+  serverName: string,
+  tools: string[],
+  options: InstallOptions = {},
+): ClaudeApprovalResult {
+  const settingsPath = getClaudeCodeSettingsPath(options);
+
+  try {
+    const settings = readJsonObject(settingsPath);
+    const permissions =
+      settings.permissions &&
+      typeof settings.permissions === "object" &&
+      !Array.isArray(settings.permissions)
+        ? (settings.permissions as Record<string, unknown>)
+        : {};
+
+    permissions.allow = addUniqueStrings(
+      permissions.allow,
+      claudeAutoApproveRules(serverName, tools),
+    );
+    settings.permissions = permissions;
+    writeJsonObject(settingsPath, settings);
+
+    return { success: true, path: settingsPath };
+  } catch (error) {
+    return {
+      success: false,
+      path: settingsPath,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
 }
 
 export function updateGitignoreWithPaths(
@@ -253,10 +379,31 @@ export function installServerForAgent(
 
     writeConfig(configPath, config, agent.format, configKey);
 
+    // Claude Code expresses auto-approval as permission rules in a separate
+    // settings file rather than inside the MCP server entry, so apply it as a
+    // side-effect once the (clean) server config is written.
+    const extraPaths: string[] = [];
+    if (agentType === "claude-code" && gatedConfig.autoApproveTools) {
+      const approval = installClaudeCodeAutoApproval(
+        serverName,
+        gatedConfig.autoApproveTools,
+        options,
+      );
+      if (!approval.success) {
+        return {
+          success: false,
+          path: approval.path,
+          error: approval.error,
+        };
+      }
+      extraPaths.push(approval.path);
+    }
+
     return {
       success: true,
       path: configPath,
       ...(dropped.length > 0 ? { droppedFields: dropped } : {}),
+      ...(extraPaths.length > 0 ? { extraPaths } : {}),
     };
   } catch (error) {
     return {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -10,7 +10,7 @@ import type { McpServerConfig } from "./types.js";
  * before its transform runs, guaranteeing that only known fields are ever
  * written to a client config.
  */
-export type OptionalField = "timeout" | "scopes";
+export type OptionalField = "timeout" | "scopes" | "autoApprove";
 
 interface OptionalFieldSpec {
   /** Human-friendly label used in user-facing "dropped" warnings. */
@@ -35,6 +35,15 @@ const OPTIONAL_FIELD_SPECS: Record<OptionalField, OptionalFieldSpec> = {
       Array.isArray(config.oauthScopes) && config.oauthScopes.length > 0,
     clear: (config) => {
       delete config.oauthScopes;
+    },
+  },
+  autoApprove: {
+    label: "tool auto-approval",
+    // An empty array is meaningful ("approve all tools"), so presence alone
+    // counts as set — unlike scopes where an empty list means "nothing".
+    isSet: (config) => Array.isArray(config.autoApproveTools),
+    clear: (config) => {
+      delete config.autoApproveTools;
     },
   },
 };
@@ -72,6 +81,7 @@ export function applyFieldSupport(
   // Defensively clone the containers we might clear so we never touch the
   // caller's nested objects/arrays.
   if (copy.oauthScopes) copy.oauthScopes = [...copy.oauthScopes];
+  if (copy.autoApproveTools) copy.autoApproveTools = [...copy.autoApproveTools];
 
   const dropped: OptionalField[] = [];
   for (const field of ALL_OPTIONAL_FIELDS) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,15 @@ export interface McpServerConfig {
    * their own native shape (e.g. Cursor `auth.scopes`, Gemini `oauth.scopes`).
    */
   oauthScopes?: string[];
+  /**
+   * Tools to auto-approve (skip the agent's per-call approval prompt). An empty
+   * array means "all tools". This is an install directive rather than a literal
+   * server-config key: capability-gated via `"autoApprove"` in `supportedFields`
+   * and each supporting agent applies it in its own way (e.g. Codex emits
+   * approval modes in its config; Claude Code writes permission allow rules to a
+   * separate settings file). It is never written into a server entry verbatim.
+   */
+  autoApproveTools?: string[];
 }
 
 export interface ConfigFile {

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -127,7 +127,11 @@ test("supportedFields reflects per-client capabilities", () => {
     "timeout",
     "scopes",
   ]);
-  assert.deepStrictEqual(agents["claude-code"].supportedFields, ["timeout"]);
+  assert.deepStrictEqual(agents["claude-code"].supportedFields, [
+    "timeout",
+    "autoApprove",
+  ]);
+  assert.deepStrictEqual(agents.codex.supportedFields, ["autoApprove"]);
   // Clients with no extra field support declare an empty list.
   assert.deepStrictEqual(agents.vscode.supportedFields, []);
   assert.deepStrictEqual(agents["claude-desktop"].supportedFields, []);

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -14,6 +14,7 @@ import { join, dirname } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import yaml from "js-yaml";
+import * as TOML from "@iarna/toml";
 
 let passed = 0;
 let failed = 0;
@@ -1385,6 +1386,182 @@ test("E2E CLI: --timeout with a package install warns and is ignored", () => {
 
   const output = `${result.stdout}\n${result.stderr}`;
   assert.match(output, /--timeout is only used for remote URLs/i);
+});
+
+test("E2E CLI: Codex auto-approve selected tool writes per-tool approval", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "executor mcp",
+      "-a",
+      "codex",
+      "-y",
+      "--name",
+      "executor",
+      "--auto-approve",
+      "--approve-tool",
+      "execute",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const saved = TOML.parse(
+    readFileSync(join(projectDir, ".codex", "config.toml"), "utf-8"),
+  ) as Record<string, unknown>;
+  const executor = (
+    saved.mcp_servers as Record<string, Record<string, unknown>>
+  ).executor;
+  assert.ok(executor);
+  const tools = executor.tools as Record<string, unknown>;
+  assert.deepStrictEqual(tools.execute, { approval_mode: "approve" });
+});
+
+test("E2E CLI: Codex --auto-approve (all tools) writes server default", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "executor mcp",
+      "-a",
+      "codex",
+      "-y",
+      "--name",
+      "executor",
+      "--auto-approve",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const saved = TOML.parse(
+    readFileSync(join(projectDir, ".codex", "config.toml"), "utf-8"),
+  ) as Record<string, unknown>;
+  const executor = (
+    saved.mcp_servers as Record<string, Record<string, unknown>>
+  ).executor;
+  assert.ok(executor);
+  assert.strictEqual(executor.default_tools_approval_mode, "approve");
+});
+
+test("E2E CLI: Claude Code auto-approve selected tool writes settings.local.json", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "executor mcp",
+      "-a",
+      "claude-code",
+      "-y",
+      "--name",
+      "executor",
+      "--auto-approve",
+      "--approve-tool",
+      "execute",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  // MCP server config stays clean
+  const mcp = JSON.parse(readFileSync(join(projectDir, ".mcp.json"), "utf-8"));
+  const server = mcp.mcpServers.executor as Record<string, unknown>;
+  assert.ok(!("autoApproveTools" in server));
+
+  // Approval lands in the separate settings file
+  const settings = JSON.parse(
+    readFileSync(join(projectDir, ".claude", "settings.local.json"), "utf-8"),
+  ) as Record<string, unknown>;
+  const permissions = settings.permissions as Record<string, unknown>;
+  assert.deepStrictEqual(permissions.allow, ["mcp__executor__execute"]);
+});
+
+test("E2E CLI: Claude Code --auto-approve (all tools) writes server-level rule", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "executor mcp",
+      "-a",
+      "claude-code",
+      "-y",
+      "--name",
+      "executor",
+      "--auto-approve",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const settings = JSON.parse(
+    readFileSync(join(projectDir, ".claude", "settings.local.json"), "utf-8"),
+  ) as Record<string, unknown>;
+  const permissions = settings.permissions as Record<string, unknown>;
+  assert.deepStrictEqual(permissions.allow, ["mcp__executor"]);
+});
+
+test("E2E CLI: auto-approve on an unsupported agent warns and writes no approval", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "cursor",
+      "-y",
+      "--name",
+      "remote",
+      "--auto-approve",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const cursor = JSON.parse(
+    readFileSync(join(projectDir, ".cursor", "mcp.json"), "utf-8"),
+  );
+  const server = cursor.mcpServers.remote as Record<string, unknown>;
+  assert.ok(!("autoApproveTools" in server));
+  assert.ok(!("tools" in server));
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /tool auto-approval is not supported by Cursor/i);
 });
 
 cleanup();

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -26,6 +26,7 @@ import {
 import { agents } from "../src/agents.js";
 import { parseSource } from "../src/source-parser.js";
 import { applyFieldSupport } from "../src/schema.js";
+import * as TOML from "@iarna/toml";
 import type { AgentType } from "../src/types.js";
 
 let passed = 0;
@@ -64,6 +65,10 @@ function cleanup() {
 function readJsonConfig(filePath: string): Record<string, unknown> {
   const content = readFileSync(filePath, "utf-8");
   return JSON.parse(content);
+}
+
+function readTomlConfig(filePath: string): Record<string, unknown> {
+  return TOML.parse(readFileSync(filePath, "utf-8")) as Record<string, unknown>;
 }
 
 // buildServerConfig tests - Remote
@@ -512,6 +517,157 @@ test("installServerForAgent - VS Code drops both timeout and scopes", () => {
   assert.strictEqual(server.url, "https://mcp.example.com/mcp");
   assert.ok(!("timeout" in server));
   assert.ok(!("oauthScopes" in server));
+});
+
+// ============================================
+// Auto-approval (Codex + Claude Code)
+// ============================================
+
+test("applyFieldSupport - empty autoApproveTools (all tools) is kept when supported", () => {
+  const { config, dropped } = applyFieldSupport(
+    { command: "x", args: [], autoApproveTools: [] },
+    ["autoApprove"],
+  );
+  assert.deepStrictEqual(config.autoApproveTools, []);
+  assert.deepStrictEqual(dropped, []);
+});
+
+test("applyFieldSupport - autoApprove dropped (and reported) when unsupported, input untouched", () => {
+  const original = { command: "x", args: [], autoApproveTools: ["run"] };
+  const { config, dropped } = applyFieldSupport(original, []);
+  assert.strictEqual(config.autoApproveTools, undefined);
+  assert.deepStrictEqual(dropped, ["autoApprove"]);
+  assert.deepStrictEqual(original.autoApproveTools, ["run"]);
+});
+
+test("installServerForAgent - Codex auto-approve selected tools writes per-tool approval", () => {
+  const tempDir = createTempDir();
+  const config = buildServerConfig(parseSource("executor mcp"), {
+    autoApproveTools: ["execute"],
+  });
+  const result = installServerForAgent("executor", config, "codex", {
+    local: true,
+    cwd: tempDir,
+  });
+  assert.ok(result.success);
+  assert.strictEqual(result.droppedFields, undefined);
+
+  const saved = readTomlConfig(join(tempDir, ".codex", "config.toml"));
+  const server = (saved.mcp_servers as Record<string, Record<string, unknown>>)
+    .executor;
+  assert.ok(server);
+  assert.deepStrictEqual(server.tools, {
+    execute: { approval_mode: "approve" },
+  });
+  assert.ok(!("autoApproveTools" in server), "directive must never be written");
+});
+
+test("installServerForAgent - Codex auto-approve all tools writes server default", () => {
+  const tempDir = createTempDir();
+  const config = buildServerConfig(parseSource("executor mcp"), {
+    autoApproveTools: [],
+  });
+  const result = installServerForAgent("executor", config, "codex", {
+    local: true,
+    cwd: tempDir,
+  });
+  assert.ok(result.success);
+
+  const saved = readTomlConfig(join(tempDir, ".codex", "config.toml"));
+  const server = (saved.mcp_servers as Record<string, Record<string, unknown>>)
+    .executor;
+  assert.ok(server);
+  assert.strictEqual(server.default_tools_approval_mode, "approve");
+});
+
+test("installServerForAgent - Claude Code auto-approve writes settings.local.json + extraPaths", () => {
+  const tempDir = createTempDir();
+  const config = buildServerConfig(parseSource("executor mcp"), {
+    autoApproveTools: ["execute"],
+  });
+  const result = installServerForAgent("executor", config, "claude-code", {
+    local: true,
+    cwd: tempDir,
+  });
+  assert.ok(result.success);
+
+  // Server config stays clean (no permission/directive leakage)
+  const mcp = readJsonConfig(join(tempDir, ".mcp.json"));
+  const server = (mcp.mcpServers as Record<string, Record<string, unknown>>)
+    .executor;
+  assert.ok(server);
+  assert.ok(!("autoApproveTools" in server));
+  assert.ok(!("permissions" in server));
+
+  // Permissions live in the separate settings file, surfaced via extraPaths
+  const settingsPath = join(tempDir, ".claude", "settings.local.json");
+  assert.deepStrictEqual(result.extraPaths, [settingsPath]);
+  const settings = readJsonConfig(settingsPath);
+  const permissions = settings.permissions as Record<string, unknown>;
+  assert.deepStrictEqual(permissions.allow, ["mcp__executor__execute"]);
+});
+
+test("installServerForAgent - Claude Code auto-approve all tools uses server-level rule", () => {
+  const tempDir = createTempDir();
+  const config = buildServerConfig(parseSource("executor mcp"), {
+    autoApproveTools: [],
+  });
+  const result = installServerForAgent("executor", config, "claude-code", {
+    local: true,
+    cwd: tempDir,
+  });
+  assert.ok(result.success);
+
+  const settings = readJsonConfig(
+    join(tempDir, ".claude", "settings.local.json"),
+  );
+  const permissions = settings.permissions as Record<string, unknown>;
+  assert.deepStrictEqual(permissions.allow, ["mcp__executor"]);
+});
+
+test("installServerForAgent - Claude Code auto-approve merges into existing permissions", () => {
+  const tempDir = createTempDir();
+  const settingsPath = join(tempDir, ".claude", "settings.local.json");
+  mkdirSync(join(tempDir, ".claude"), { recursive: true });
+  writeFileSync(
+    settingsPath,
+    JSON.stringify({ permissions: { allow: ["Bash(ls)"] } }),
+  );
+
+  const config = buildServerConfig(parseSource("executor mcp"), {
+    autoApproveTools: ["execute"],
+  });
+  installServerForAgent("executor", config, "claude-code", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  const settings = readJsonConfig(settingsPath);
+  const permissions = settings.permissions as Record<string, unknown>;
+  assert.deepStrictEqual(permissions.allow, [
+    "Bash(ls)",
+    "mcp__executor__execute",
+  ]);
+});
+
+test("installServerForAgent - unsupported agent drops autoApprove with no leak", () => {
+  const tempDir = createTempDir();
+  const config = buildServerConfig(parseSource("https://mcp.example.com/mcp"), {
+    autoApproveTools: ["execute"],
+  });
+  const result = installServerForAgent("example", config, "cursor", {
+    local: true,
+    cwd: tempDir,
+  });
+  assert.ok(result.success);
+  assert.deepStrictEqual(result.droppedFields, ["autoApprove"]);
+
+  const saved = readJsonConfig(join(tempDir, ".cursor", "mcp.json"));
+  const server = (saved.mcpServers as Record<string, Record<string, unknown>>)
+    .example;
+  assert.ok(server);
+  assert.ok(!("autoApproveTools" in server));
+  assert.ok(!("tools" in server));
 });
 
 // ============================================


### PR DESCRIPTION
## Summary

Adds `--auto-approve` and repeatable `--approve-tool <tool>` to preconfigure agent-level MCP tool approval at install time — useful for servers that already gate actions internally, so the agent doesn't prompt on every call.

This is a rework of #32 (@RhysSullivan) on top of the capability-gating model that landed in #55. Co-authored with @RhysSullivan.

## How it works

- `--auto-approve` approves all tools; `--approve-tool <name>` (repeatable) scopes it to specific tools. `--approve-tool` implies `--auto-approve`.
- Modeled as a capability-gated field (`"autoApprove"` in each agent's `supportedFields`), reusing #55's drop-warning machinery. Only **Codex** and **Claude Code** support it; other agents drop it with a warning (_"tool auto-approval is not supported by Cursor; dropped from that config."_).
- **Codex** → `config.toml`: per-tool `tools.<name>.approval_mode = "approve"`, or `default_tools_approval_mode = "approve"` for all tools.
- **Claude Code** → permission allow rules in a **separate** settings file (`.claude/settings.local.json` for project installs, `~/.claude/settings.json` for global): `mcp__<server>__<tool>`, or `mcp__<server>` for all tools. The MCP server entry stays clean. The settings path is surfaced in the result summary and included in `--gitignore`.

## Differences from #32

- Built on #55's required-`transformConfig` model (no raw passthrough), so the directive can't leak into a server entry.
- Unsupported agents now **warn** instead of silently ignoring (reuses the `supportedFields` drop mechanism).
- The Claude settings file is surfaced to the user and `--gitignore`.
- Added a code comment + README note on the known Claude Code all-tools bug ([#34739](https://github.com/anthropics/claude-code/issues/34739)); explicit `--approve-tool` is the reliable path.

## Validation

- Config formats verified against the [Codex MCP docs](https://developers.openai.com/codex/mcp) and [Claude Code settings docs](https://code.claude.com/docs/en/settings).
- `bun run typecheck`, `bun run build`, full `bun run test` (unit + e2e) all green, with new coverage for per-tool/all-tools paths, the unsupported-agent warning, the clean-server-entry guarantee, and merging into existing permissions.
- **Live end-to-end**: ran the real CLI to install `@modelcontextprotocol/server-everything` to Codex/Claude Code/Cursor/MCPorter with `--auto-approve --approve-tool echo`; inspected all generated files; then used **mcporter** to connect to the live server via the generated config and successfully call the real `echo` tool. Codex CLI isn't installed locally, but the TOML matches the documented schema and @RhysSullivan validated runtime approval with real `codex exec` in #32.

## Test plan

- [x] typecheck / build / full suite
- [x] live mcporter round-trip against a real MCP server
- [x] manual inspection of Codex TOML + Claude settings + clean `.mcp.json`/Cursor configs