### PR TITLE
[codex] feat: prompt for install scope interactively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.13.0] - 2026-06-29
+
+- add interactive project/global scope selection after agent selection when every selected agent supports both scopes; `-g` still forces global and `-y` stays deterministic.
+- use one shared install scope per run: selections that include any global-only agent now install globally for all selected agents instead of mixing project and global configs.
+
 ## [1.12.0] - 2026-06-21
 
 - add `--auto-approve` and repeatable `--approve-tool <tool>` to preconfigure agent-level MCP tool approval. Capability-gated per client and mapped to each client's native mechanism: Codex writes approval modes to `config.toml` (`tools.<name>.approval_mode = "approve"`, or `default_tools_approval_mode` for all tools); Claude Code writes permission allow rules (`mcp__<server>__<tool>`, or `mcp__<server>` for all tools) to a separate settings file (`.claude/settings.local.json` for project installs, `~/.claude/settings.json` for global) while keeping the MCP server entry clean. Agents that don't support auto-approval have it dropped with a warning. Co-authored with @RhysSullivan ([#32](https://github.com/neon-solutions/add-mcp/pull/32))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -653,6 +653,18 @@ export function supportsProjectConfig(agentType: AgentType): boolean {
   return agents[agentType].localConfigPath !== undefined;
 }
 
+export type InstallScope = "local" | "global";
+
+export function getCommonInstallScopes(
+  agentTypes: AgentType[],
+): InstallScope[] {
+  if (agentTypes.length === 0) return [];
+  if (agentTypes.some((agentType) => !supportsProjectConfig(agentType))) {
+    return ["global"];
+  }
+  return ["local", "global"];
+}
+
 export function getProjectCapableAgents(): AgentType[] {
   return (Object.keys(agents) as AgentType[]).filter((type) =>
     supportsProjectConfig(type),

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,9 +13,11 @@ import {
   detectProjectAgents,
   detectGlobalAgents,
   supportsProjectConfig,
+  getCommonInstallScopes,
   getProjectCapableAgents,
   buildAgentSelectionChoices,
   selectAgentsInteractive,
+  type InstallScope,
 } from "./agents.js";
 import {
   getFindRegistries,
@@ -1546,12 +1548,9 @@ async function main(target: string | undefined, options: Options) {
   // Determine target agents
   let targetAgents: AgentType[];
   const allAgentTypes = getAgentTypes();
-  const hasExplicitAgentFlags =
-    (options.agent && options.agent.length > 0) || options.all === true;
-  let selectedViaPrompt = false;
 
   // Track which agents should use local vs global config
-  // This will be populated based on detection and user choices
+  // This starts with detection hints, then is overwritten with the final scope.
   let agentRouting: Map<AgentType, "local" | "global"> = new Map();
 
   if (options.agent && options.agent.length > 0) {
@@ -1626,9 +1625,7 @@ async function main(target: string | undefined, options: Options) {
           );
         }
       } else {
-        const availableAgents = options.global
-          ? allAgentTypes
-          : getProjectCapableAgents();
+        const availableAgents = allAgentTypes;
 
         p.log.warn(
           options.global
@@ -1645,11 +1642,7 @@ async function main(target: string | undefined, options: Options) {
           process.exit(0);
         }
 
-        selectedViaPrompt = true;
         targetAgents = selected as AgentType[];
-        for (const agent of targetAgents) {
-          agentRouting.set(agent, options.global ? "global" : "local");
-        }
       }
     } else if (options.yes) {
       targetAgents = detectedAgents;
@@ -1658,9 +1651,7 @@ async function main(target: string | undefined, options: Options) {
         .join(", ");
       p.log.info(`Installing to: ${agentNames}`);
     } else {
-      const availableAgents = options.global
-        ? allAgentTypes
-        : getProjectCapableAgents();
+      const availableAgents = allAgentTypes;
       let lastSelected: string[] | undefined;
       try {
         lastSelected = await getLastSelectedAgents();
@@ -1687,11 +1678,7 @@ async function main(target: string | undefined, options: Options) {
         process.exit(0);
       }
 
-      selectedViaPrompt = true;
       targetAgents = selected as AgentType[];
-      for (const agent of targetAgents) {
-        agentRouting.set(agent, options.global ? "global" : "local");
-      }
     }
   }
 
@@ -1741,69 +1728,53 @@ async function main(target: string | undefined, options: Options) {
     }
   }
 
-  // Determine installation scope (global vs local)
-  // If we already have routing from smart detection, use that
-  // Otherwise, determine scope and build routing
-
-  const hasSmartRouting = agentRouting.size > 0;
-
+  // Determine one common installation scope (global vs project). The CLI never
+  // mixes scopes within a single install: if any selected agent is global-only,
+  // global is the only common scope.
   if (options.global) {
     // Explicit global flag - route all agents to global
+    agentRouting = new Map();
     for (const agent of targetAgents) {
       agentRouting.set(agent, "global");
     }
-  } else if (!hasSmartRouting) {
-    // No smart routing yet - need to determine scope
-    // This happens when user specifies --agent or --all without --global
-
-    // Check if any selected agents support local config
-    const selectedWithLocal = targetAgents.filter((a) =>
-      supportsProjectConfig(a),
-    );
-    const globalOnlySelected = targetAgents.filter(
-      (a) => !supportsProjectConfig(a),
-    );
-
-    // Global-only agents always go to global
-    for (const agent of globalOnlySelected) {
-      agentRouting.set(agent, "global");
+  } else {
+    const commonScopes = getCommonInstallScopes(targetAgents);
+    if (commonScopes.length === 0) {
+      p.log.error("No agents selected");
+      process.exit(1);
     }
 
-    if (selectedWithLocal.length > 0) {
-      let installLocally = true; // Default to local/project
+    let installScope: InstallScope = commonScopes[0]!;
+    if (commonScopes.length > 1 && !options.yes) {
+      const scope = await p.select({
+        message: "Installation scope",
+        options: [
+          {
+            value: "local",
+            label: "Project",
+            hint: "Install in current directory (committed with your project)",
+          },
+          {
+            value: "global",
+            label: "Global",
+            hint: "Install in home directory (available across all projects)",
+          },
+        ],
+      });
 
-      if (!options.yes) {
-        const scope = await p.select({
-          message: "Installation scope",
-          options: [
-            {
-              value: true,
-              label: "Project",
-              hint: "Install in current directory (committed with your project)",
-            },
-            {
-              value: false,
-              label: "Global",
-              hint: "Install in home directory (available across all projects)",
-            },
-          ],
-        });
-
-        if (p.isCancel(scope)) {
-          p.cancel("Installation cancelled");
-          process.exit(0);
-        }
-
-        installLocally = scope as boolean;
+      if (p.isCancel(scope)) {
+        p.cancel("Installation cancelled");
+        process.exit(0);
       }
 
-      // Route project-capable agents based on user choice
-      for (const agent of selectedWithLocal) {
-        agentRouting.set(agent, installLocally ? "local" : "global");
-      }
-    } else {
-      // All selected agents only support global config
-      p.log.info("Selected agents only support global installation");
+      installScope = scope as InstallScope;
+    } else if (installScope === "global") {
+      p.log.info("Selected agents require global installation");
+    }
+
+    agentRouting = new Map();
+    for (const agent of targetAgents) {
+      agentRouting.set(agent, installScope);
     }
   }
 
@@ -1829,16 +1800,7 @@ async function main(target: string | undefined, options: Options) {
     (a) => agentRouting.get(a) === "global",
   );
 
-  if (localAgents.length > 0 && globalAgents.length > 0) {
-    // Mixed routing
-    summaryLines.push(`${chalk.cyan("Scope:")} Mixed (project + global)`);
-    summaryLines.push(
-      `${chalk.cyan("  Project:")} ${localAgents.map((a) => agents[a].displayName).join(", ")}`,
-    );
-    summaryLines.push(
-      `${chalk.cyan("  Global:")} ${globalAgents.map((a) => agents[a].displayName).join(", ")}`,
-    );
-  } else if (localAgents.length > 0) {
+  if (localAgents.length > 0) {
     summaryLines.push(`${chalk.cyan("Scope:")} Project`);
     summaryLines.push(
       `${chalk.cyan("Agents:")} ${localAgents.map((a) => agents[a].displayName).join(", ")}`,
@@ -1936,7 +1898,7 @@ async function main(target: string | undefined, options: Options) {
     );
   }
 
-  if (options.gitignore && options.global) {
+  if (options.gitignore && localAgents.length === 0) {
     p.log.warn(
       "--gitignore is only supported for project-scoped installations; ignoring.",
     );

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -14,6 +14,7 @@ import {
   agents,
   getAgentTypes,
   supportsProjectConfig,
+  getCommonInstallScopes,
   getProjectCapableAgents,
   getGlobalOnlyAgents,
   detectProjectAgents,
@@ -196,6 +197,25 @@ test("Project + global-only agents equals all agents", () => {
   const all = [...allAgents].sort();
 
   assert.deepStrictEqual(combined, all);
+});
+
+test("getCommonInstallScopes returns project and global for project-capable agents", () => {
+  assert.deepStrictEqual(getCommonInstallScopes(["cursor", "codex"]), [
+    "local",
+    "global",
+  ]);
+});
+
+test("getCommonInstallScopes returns global for global-only agents", () => {
+  assert.deepStrictEqual(getCommonInstallScopes(["claude-desktop"]), [
+    "global",
+  ]);
+});
+
+test("getCommonInstallScopes returns global when selection mixes capabilities", () => {
+  assert.deepStrictEqual(getCommonInstallScopes(["cursor", "claude-desktop"]), [
+    "global",
+  ]);
 });
 
 // ============================================

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -246,6 +246,70 @@ test("E2E CLI: --gitignore with --global warns and does not write project .gitig
   assert.strictEqual(existsSync(join(homeDir, ".cursor", "mcp.json")), true);
 });
 
+test("E2E CLI: -y keeps project-capable agents project-scoped by default", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "@modelcontextprotocol/server-filesystem",
+      "-a",
+      "cursor",
+      "-y",
+      "--name",
+      "project-scope",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  assert.strictEqual(existsSync(join(projectDir, ".cursor", "mcp.json")), true);
+  assert.strictEqual(existsSync(join(homeDir, ".cursor", "mcp.json")), false);
+});
+
+test("E2E CLI: global-only selections force a shared global scope", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "@modelcontextprotocol/server-filesystem",
+      "-a",
+      "cursor",
+      "-a",
+      "claude-desktop",
+      "-y",
+      "--name",
+      "shared-global-scope",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  assert.strictEqual(
+    existsSync(join(projectDir, ".cursor", "mcp.json")),
+    false,
+  );
+  assert.strictEqual(existsSync(join(homeDir, ".cursor", "mcp.json")), true);
+  assert.strictEqual(existsSync(claudeDesktopConfigPath(homeDir)), true);
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /Selected agents require global installation/);
+  assert.match(output, /Scope:\s*Global/);
+});
+
 test("E2E CLI: find -y without registry config asks to configure registries", () => {
   const projectDir = createTempDir();
   const homeDir = createTempDir();


### PR DESCRIPTION
## Summary

- Prompt for project vs global scope after agent selection when every selected agent supports both scopes.
- Use one shared scope per install: if the selection includes any global-only agent, route all selected agents globally instead of mixing project and global configs.
- Bump the package to `1.13.0` and add the changelog entry for the releasable changeset.

Closes #57

## Validation

- `bun run fmt`
- `bun run build`
- `bun run typecheck`
- `bun run test`
- `bun run registry:verify`
- `bun run fallow -- --summary` exits nonzero on existing advisory findings: `tests/formats-utils.test.ts` unused, four pre-existing unused exports, duplicate blocks, and existing `src/index.ts` complexity. The new scope helper is not reported as unused.
